### PR TITLE
Bug Fix

### DIFF
--- a/madminer/likelihood.py
+++ b/madminer/likelihood.py
@@ -66,6 +66,10 @@ class BaseLikelihood(DataAnalyzer):
             weights = self._weights([theta], [nu], weights_benchmarks)[0]
             xsec=sum(weights)
         
+        if xsec<0:
+            logger.warning("Total cross section is negative (%s pb) at theta=%s)",xsec,theta)
+            xsec=0
+        
         n_predicted = xsec * luminosity
         n_observed_rounded = int(np.round(n_observed, 0))
 
@@ -373,8 +377,6 @@ class HistoLikelihood(BaseLikelihood):
                 total_weights = np.array([sum(weights_benchmark) for weights_benchmark in weights_benchmarks.T])
         else:
             total_weights,benchmark_histograms=None,None
-        
-        benchmark_histograms
 
         #define negative likelihood function
         def nll(params):

--- a/madminer/likelihood.py
+++ b/madminer/likelihood.py
@@ -148,7 +148,7 @@ class NeuralLikelihood(BaseLikelihood):
    ):
         """
         Low-level function which calculates the value of the log-likelihood ratio.
-        See create_negative_log_likelihood for options.
+        See create_negative_log_likelihood for options.   
         """
         
         log_likelihood = 0.0

--- a/madminer/likelihood.py
+++ b/madminer/likelihood.py
@@ -164,6 +164,10 @@ class NeuralLikelihood(BaseLikelihood):
         return log_likelihood
 
     def _log_likelihood_kinematic(self, estimator, xs, theta, nu):
+        """
+        Low-level function which calculates the value of the kinematic part of the
+        log-likelihood. See create_negative_log_likelihood for options.
+        """
         if nu is not None:
             theta = np.concatenate((theta, nu), axis=0)
         

--- a/madminer/likelihood.py
+++ b/madminer/likelihood.py
@@ -146,6 +146,11 @@ class NeuralLikelihood(BaseLikelihood):
         x_weights=None,
         weights_benchmarks=None,
    ):
+        """
+        Low-level function which calculates the value of the log-likelihood ratio.
+        See create_negative_log_likelihood for options.
+        """
+        
         log_likelihood = 0.0
         if include_xsec:
             log_likelihood = log_likelihood + self._log_likelihood_poisson(n_events, theta, nu, luminosity, weights_benchmarks)
@@ -168,6 +173,7 @@ class NeuralLikelihood(BaseLikelihood):
         Low-level function which calculates the value of the kinematic part of the
         log-likelihood. See create_negative_log_likelihood for options.
         """
+        
         if nu is not None:
             theta = np.concatenate((theta, nu), axis=0)
         


### PR DESCRIPTION
If expected # of events is <=0, the poisson LLR is nan. I fixed that my setting the expected number of events to 10**-5, when xsec <=0. 