### PR TITLE
Update outdated doc strings

### DIFF
--- a/madminer/sampling/sampleaugmenter.py
+++ b/madminer/sampling/sampleaugmenter.py
@@ -446,6 +446,7 @@ class SampleAugmenter(DataAnalyzer):
             n_processes=n_processes,
             log_message=False,
             n_eff_forced=n_eff_forced,
+            double_precision=double_precision,
         )
 
     def sample_train_ratio(
@@ -1139,6 +1140,7 @@ class SampleAugmenter(DataAnalyzer):
             test_split=test_split,
             n_processes=n_processes,
             sample_only_from_closest_benchmark=sample_only_from_closest_benchmark,
+            n_eff_forced=n_eff_forced,
             double_precision=double_precision,
         )
 

--- a/madminer/sampling/sampleaugmenter.py
+++ b/madminer/sampling/sampleaugmenter.py
@@ -122,9 +122,11 @@ class SampleAugmenter(DataAnalyzer):
             Fraction of events reserved for the evaluation sample (that will not be used for any training samples).
             Default value: 0.2.
 
-        switch_train_test_events : bool, optional
-            If True, this function generates a training sample from the events normally reserved for test samples.
-            Default value: False.
+        validation_split : float or None, optional
+            Fraction of events reserved for testing. Default value: 0.2.
+
+        partition : {"train", "test", "validation", "all"}, optional
+            Which event partition to use. Default value: "train".
 
         n_processes : None or int, optional
             If None or larger than 1, MadMiner will use multiprocessing to parallelize the sampling. In this case,
@@ -240,9 +242,11 @@ class SampleAugmenter(DataAnalyzer):
             Fraction of events reserved for the evaluation sample (that will not be used for any training samples).
             Default value: 0.2.
 
-        switch_train_test_events : bool, optional
-            If True, this function generates a training sample from the events normally reserved for test samples.
-            Default value: False.
+        validation_split : float or None, optional
+            Fraction of events reserved for testing. Default value: 0.2.
+
+        partition : {"train", "test", "validation", "all"}, optional
+            Which event partition to use. Default value: "train".
 
         n_processes : None or int, optional
             If None or larger than 1, MadMiner will use multiprocessing to parallelize the sampling. In this case,
@@ -383,9 +387,11 @@ class SampleAugmenter(DataAnalyzer):
             Fraction of events reserved for the evaluation sample (that will not be used for any training samples).
             Default value: 0.2.
 
-        switch_train_test_events : bool, optional
-            If True, this function generates a training sample from the events normally reserved for test samples.
-            Default value: False.
+        validation_split : float or None, optional
+            Fraction of events reserved for testing. Default value: 0.2.
+
+        partition : {"train", "test", "validation", "all"}, optional
+            Which event partition to use. Default value: "train".
 
         n_processes : None or int, optional
             If None or larger than 1, MadMiner will use multiprocessing to parallelize the sampling. In this case,
@@ -510,9 +516,11 @@ class SampleAugmenter(DataAnalyzer):
             Fraction of events reserved for the evaluation sample (that will not be used for any training samples).
             Default value: 0.2.
 
-        switch_train_test_events : bool, optional
-            If True, this function generates a training sample from the events normally reserved for test samples.
-            Default value: False.
+        validation_split : float or None, optional
+            Fraction of events reserved for testing. Default value: 0.2.
+
+        partition : {"train", "test", "validation", "all"}, optional
+            Which event partition to use. Default value: "train".
 
         n_processes : None or int, optional
             If None or larger than 1, MadMiner will use multiprocessing to parallelize the sampling. In this case,
@@ -783,9 +791,11 @@ class SampleAugmenter(DataAnalyzer):
             Fraction of events reserved for the evaluation sample (that will not be used for any training samples).
             Default value: 0.2.
 
-        switch_train_test_events : bool, optional
-            If True, this function generates a training sample from the events normally reserved for test samples.
-            Default value: False.
+        validation_split : float or None, optional
+            Fraction of events reserved for testing. Default value: 0.2.
+
+        partition : {"train", "test", "validation", "all"}, optional
+            Which event partition to use. Default value: "train".
 
         n_processes : None or int, optional
             If None or larger than 1, MadMiner will use multiprocessing to parallelize the sampling. In this case,
@@ -1076,9 +1086,11 @@ class SampleAugmenter(DataAnalyzer):
             Fraction of events reserved for the evaluation sample (that will not be used for any training samples).
             Default value: 0.2.
 
-        switch_train_test_events : bool, optional
-            If True, this function generates a test sample from the events normally reserved for training samples.
-            Default value: False.
+        validation_split : float or None, optional
+            Fraction of events reserved for testing. Default value: 0.2.
+
+        partition : {"train", "test", "validation", "all"}, optional
+            Which event partition to use. Default value: "test".
 
         n_processes : None or int, optional
             If None or larger than 1, MadMiner will use multiprocessing to parallelize the sampling. In this case,


### PR DESCRIPTION
This PR mainly updates the `SampleAugmenter` methods doc strings, as their arguments were changed in [this commit](https://github.com/diana-hep/madminer/commit/fa3e2e8f4ca40418b8b589d7d88a3a64c9e65878), but the doc strings were not.

In addition, I have added some unused method arguments into their `self.sample_train_local` and `self._sample` subcalls. I have assumed that _"downfall argument propagation"_ was desired when implementing these methods.

Finally, I think there is no need for a version bump up. Feel free to it if you think so.