### PR TITLE
Improve 'core' and 'utils' doc strings

### DIFF
--- a/madminer/core/madminer.py
+++ b/madminer/core/madminer.py
@@ -726,10 +726,6 @@ class MadMiner:
             If True, the event generation is not started, but instead a run.sh script is created in the process
             directory. Default value: False.
 
-        only_prepare_script : bool, optional
-            If True, MadGraph is not executed, but instead a run.sh script is created in
-            the process directory. Default value: False.
-
         ufo_model_directory : str or None, optional
             Path to an UFO model directory that should be used, but is not yet installed in mg_directory/models. The
             model will be copied to the MadGraph model directory before the process directory is generated. (Default
@@ -848,10 +844,6 @@ class MadMiner:
         only_prepare_script : bool, optional
             If True, the event generation is not started, but instead a run.sh script is created in the process
             directory. Default value: False.
-
-        only_prepare_script : bool, optional
-            If True, MadGraph is not executed, but instead a run.sh script is created in
-            the process directory. Default value: False.
 
         ufo_model_directory : str or None, optional
             Path to an UFO model directory that should be used, but is not yet installed in mg_directory/models. The

--- a/madminer/core/madminer.py
+++ b/madminer/core/madminer.py
@@ -1002,12 +1002,8 @@ class MadMiner:
                         run_card_file_from_mgprocdir=new_run_card_file,
                         param_card_file_from_mgprocdir=param_card_file,
                         reweight_card_file_from_mgprocdir=reweight_card_file,
-                        pythia8_card_file_from_mgprocdir=None
-                        if new_pythia8_card_file is None
-                        else new_pythia8_card_file,
-                        configuration_file_from_mgprocdir=None
-                        if new_configuration_file is None
-                        else new_configuration_file,
+                        pythia8_card_file_from_mgprocdir=new_pythia8_card_file,
+                        configuration_file_from_mgprocdir=new_configuration_file,
                         is_background=is_background,
                         script_file_from_mgprocdir=script_file,
                         initial_command=initial_command,

--- a/madminer/core/madminer.py
+++ b/madminer/core/madminer.py
@@ -945,18 +945,18 @@ class MadMiner:
                 # Files
                 script_file = "madminer/scripts/run_{}.sh".format(i)
                 log_file_run = "run_{}.log".format(i)
-                mg_commands_filename = "/madminer/cards/mg_commands_{}.dat".format(i)
-                param_card_file = "/madminer/cards/param_card_{}.dat".format(i)
-                reweight_card_file = "/madminer/cards/reweight_card_{}.dat".format(i)
+                mg_commands_filename = "madminer/cards/mg_commands_{}.dat".format(i)
+                param_card_file = "madminer/cards/param_card_{}.dat".format(i)
+                reweight_card_file = "madminer/cards/reweight_card_{}.dat".format(i)
                 new_pythia8_card_file = None
                 if pythia8_card_file is not None:
-                    new_pythia8_card_file = "/madminer/cards/pythia8_card_{}.dat".format(i)
+                    new_pythia8_card_file = "madminer/cards/pythia8_card_{}.dat".format(i)
                 new_run_card_file = None
                 if run_card_file is not None:
-                    new_run_card_file = "/madminer/cards/run_card_{}.dat".format(i)
+                    new_run_card_file = "madminer/cards/run_card_{}.dat".format(i)
                 new_configuration_file = None
                 if configuration_file is not None:
-                    new_configuration_file = "/madminer/cards/me5_configuration_{}.txt".format(i)
+                    new_configuration_file = "madminer/cards/me5_configuration_{}.txt".format(i)
 
                 logger.info("Run %s", i)
                 logger.info("  Sampling from benchmark: %s", sample_benchmark)

--- a/madminer/utils/interfaces/mg.py
+++ b/madminer/utils/interfaces/mg.py
@@ -128,8 +128,8 @@ def setup_mg_with_scripts(
     pythia8_card_file_from_mgprocdir : str or None, optional
         Path to the MadGraph Pythia8 card, relative from mg_process_directory. If None, Pythia is not run. Default
         value: None.
-        
-        configuration_file_from_mgprocdir : str or None, optional
+
+    configuration_file_from_mgprocdir : str or None, optional
         Path to the MadGraph me5_configuration card, relative from mg_process_directory. If None, the card
         present in the process folder is used. Default value: None.
 


### PR DESCRIPTION
This PR brings aesthetic changes to the MadMiner `core` and `utils` packages. Basically:

- Deletion of duplicated doc-string arguments.
- Deletion of redundant `/` character when defining MadGraph card paths (every time those variables are used, they are preceded by a `+ '/' + ` snippet).
- Deletion of unnecessary argument check when calling [setup_mg_with_scripts](https://github.com/diana-hep/madminer/blob/master/madminer/core/madminer.py#L1007) within the [run_multiple](https://github.com/diana-hep/madminer/blob/master/madminer/core/madminer.py#L784) function (Unless something more logical was planned to occur there, and due to typos ended up as a silly logic).
- Fix doc-string arguments indentation.

Due to the nature of this PR, I have not updated the version.
