### PR TITLE
Improve DelphesReader input checks

### DIFF
--- a/madminer/delphes/delphes_reader.py
+++ b/madminer/delphes/delphes_reader.py
@@ -164,18 +164,23 @@ class DelphesReader:
 
         """
 
-        logger.debug("Adding event sample %s", hepmc_filename)
-
         # Check inputs
-        assert weights in ["delphes", "lhe"], "Unknown setting for weights: %s. Has to be 'delphes' or 'lhe'."
+        if not os.path.exists(hepmc_filename):
+            raise ValueError("The specified hepmc file does not exist")
 
-        if self.systematics is not None:
-            if lhe_filename is None:
-                raise ValueError("With systematic uncertainties, a LHE event file has to be provided.")
+        if lhe_filename and not os.path.exists(lhe_filename):
+            raise ValueError("The specified lhe file does not exist")
 
-        if weights == "lhe":
-            if lhe_filename is None:
-                raise ValueError("With weights = 'lhe', a LHE event file has to be provided.")
+        if weights not in ["delphes", "lhe"]:
+            raise ValueError("Unknown setting for weights. Has to be 'delphes' or 'lhe'.")
+
+        if weights == "lhe" and lhe_filename is None:
+            raise ValueError("With weights = 'lhe', a LHE event file has to be provided.")
+
+        if self.systematics and lhe_filename is None:
+            raise ValueError("With systematic uncertainties, a LHE event file has to be provided.")
+
+        logger.debug("Adding event sample %s", hepmc_filename)
 
         self.hepmc_sample_filenames.append(hepmc_filename)
         self.hepmc_sampled_from_benchmark.append(sampled_from_benchmark)

--- a/madminer/delphes/delphes_reader.py
+++ b/madminer/delphes/delphes_reader.py
@@ -339,6 +339,8 @@ class DelphesReader:
 
         """
 
+        self._check_python_syntax(definition)
+
         if required:
             logger.debug("Adding required observable %s = %s", name, definition)
         else:
@@ -499,6 +501,9 @@ class DelphesReader:
             None
 
         """
+
+        self._check_python_syntax(definition)
+
         logger.debug("Adding cut %s", definition)
 
         self.cuts.append(definition)
@@ -807,6 +812,27 @@ class DelphesReader:
                 this_weights[key] = reference_weights / sampling_weights * this_weights[key]
 
         return this_observations, this_weights, n_events
+
+    def _check_python_syntax(self, expression):
+        """
+        Evaluates a Python expression to check for syntax errors
+
+        Parameters
+        ----------
+        expression : str
+            Python expression to be evaluated. The evaluation raises either SyntaxError or NameError
+
+        Returns
+        -------
+            None
+        """
+
+        try:
+            eval(expression)
+        except SyntaxError:
+            raise ValueError("The provided Python expression is invalid")
+        except NameError:
+            pass
 
     def _check_sample_observations(self, this_observations):
         """ Sanity checks """


### PR DESCRIPTION
This PR aims to improve the input verification of:

- [DelphesReader.add_sample](https://github.com/diana-hep/madminer/blob/master/madminer/delphes/delphes_reader.py#L106), receiving file paths
- [DelphesReader.add_observable](https://github.com/diana-hep/madminer/blob/master/madminer/delphes/delphes_reader.py#L300), receiving Python expressions in string format.
- [DelphesReader.add_cut](https://github.com/diana-hep/madminer/blob/master/madminer/delphes/delphes_reader.py#L469), receiving Python expressions in string format

By checking for valid inputs before performing any further actions.

**Considerations:**
1. The [DelphesReader.add_sample](https://github.com/diana-hep/madminer/blob/master/madminer/delphes/delphes_reader.py#L106) function has also suffered a re-organization of these input argument checks (now in the same order the arguments they check are defined in the function signature).
2. When evaluating a Python expression, `SyntaxError` raises earlier than any other exception. (`NameError` is ignored as it is the one that we expect to receive).
3. I have not bumped up the version.