### PR TITLE
Update dockerfile to Ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,15 @@ FROM rootproject/root-ubuntu16
 
 USER root
 
-RUN apt-get update && apt-get install -y python3-pip python python-pip python3-tk python-tk
+RUN apt-get update && apt-get install -y \
+    python
+    python-tk
+    python-pip
+    python3-tk
+    python3-pip
 
-RUN pip install --upgrade pip
 
-RUN pip install madminer --upgrade  
+RUN pip install --upgrade --no-cache-dir pip && \
+    pip install --upgrade --no-cache-dir madminer
 
 WORKDIR /home/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-#docker image that contains madminer and root
-FROM rootproject/root-ubuntu16
+# Docker image that contains madminer and root
+FROM rootproject/root-ubuntu
 
 USER root
 


### PR DESCRIPTION
**~Disclaimer: `root-ubuntu20` image is not yet published. Do NOT merge.~**

Following the refactor performed in the [Scailfin/madminer-workflow](https://github.com/scailfin/workflow-madminer) repository, a base image with newer Python3 version was needed (at least Python 3.6).

I realized the base image Madminer used for its Docker image, `rootproject/root-ubuntu16`, was lagging behind the current state of Ubuntu (currently at Ubuntu 20.04). Therefore, I proposed an [upgrade to Ubuntu20 ](https://github.com/root-project/root-docker/pull/11), which has been recently approved.

I am assuming it will soon be published under the `rootproject` Dockerhub account.

---

In addition:
- I have listed the required `apt-get` packages in a vertical fashion.
- I have added the `--no-cache-dir` option to pip installations.