### PR TITLE
Fix dockerfile Python2 installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,14 @@ FROM rootproject/root-ubuntu
 USER root
 
 RUN apt-get update && apt-get install -y \
-    python
-    python-tk
-    python-pip
-    python3-tk
+    python-dev \
+    python-tk \
+    python3-tk \
     python3-pip
 
+# Python2 pip is not longer shiped with Ubuntu (20.04+)
+RUN curl "https://bootstrap.pypa.io/get-pip.py" --output get-pip.py && \
+    python get-pip.py
 
 RUN pip install --upgrade --no-cache-dir pip && \
     pip install --upgrade --no-cache-dir madminer


### PR DESCRIPTION
This PR fixes some non-considered bugs introduced in the previous PR (https://github.com/diana-hep/madminer/pull/427):

1. From Ubuntu 20.04, Python2 `pip` package can no longer be installed using the `python-pip` rule. I followed [this guide](https://linuxize.com/post/how-to-install-pip-on-ubuntu-20.04/#installing-pip-for-python-2) in order to get Python2 `pip` from the Python Package Authority ([PyPA](https://github.com/pypa)).

2. When installing MadMiner, `python-dev` instead of `python` need to be installed. The _"-dev"_ version includes the necessary headers for building the `subprocess32` binary.

---

Sorry for letting these bugs slip in...