### PR TITLE
Update particle physics tutorial

### DIFF
--- a/examples/tutorial_particle_physics/1_setup.ipynb
+++ b/examples/tutorial_particle_physics/1_setup.ipynb
@@ -84,7 +84,7 @@
       "11:15 madminer             INFO    \n",
       "11:15 madminer             INFO    ------------------------------------------------------------------------\n",
       "11:15 madminer             INFO    |                                                                      |\n",
-      "11:15 madminer             INFO    |  MadMiner v0.7.0                                                     |\n",
+      "11:15 madminer             INFO    |  MadMiner v0.7.4                                                     |\n",
       "11:15 madminer             INFO    |                                                                      |\n",
       "11:15 madminer             INFO    |         Johann Brehmer, Felix Kling, Irina Espejo, and Kyle Cranmer  |\n",
       "11:15 madminer             INFO    |                                                                      |\n",

--- a/examples/tutorial_particle_physics/2a_parton_level_analysis.ipynb
+++ b/examples/tutorial_particle_physics/2a_parton_level_analysis.ipynb
@@ -78,7 +78,7 @@
       "11:16 madminer             INFO    \n",
       "11:16 madminer             INFO    ------------------------------------------------------------------------\n",
       "11:16 madminer             INFO    |                                                                      |\n",
-      "11:16 madminer             INFO    |  MadMiner v0.7.0                                                     |\n",
+      "11:16 madminer             INFO    |  MadMiner v0.7.4                                                     |\n",
       "11:16 madminer             INFO    |                                                                      |\n",
       "11:16 madminer             INFO    |         Johann Brehmer, Felix Kling, Irina Espejo, and Kyle Cranmer  |\n",
       "11:16 madminer             INFO    |                                                                      |\n",

--- a/examples/tutorial_particle_physics/2a_parton_level_analysis.ipynb
+++ b/examples/tutorial_particle_physics/2a_parton_level_analysis.ipynb
@@ -104,7 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mg_dir = '/home/software/MG5_aMC_v2_6_7'"
+    "mg_dir = '/madminer/software/MG5_aMC_v2_6_7'"
    ]
   },
   {

--- a/examples/tutorial_particle_physics/2b_delphes_level_analysis.ipynb
+++ b/examples/tutorial_particle_physics/2b_delphes_level_analysis.ipynb
@@ -88,7 +88,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mg_dir = '/home/software/MG5_aMC_v2_6_7/'"
+    "mg_dir = '/madminer/software/MG5_aMC_v2_6_7/'"
    ]
   },
   {

--- a/examples/tutorial_particle_physics/3a_likelihood_ratio.ipynb
+++ b/examples/tutorial_particle_physics/3a_likelihood_ratio.ipynb
@@ -71,7 +71,7 @@
       "11:18 madminer             INFO    \n",
       "11:18 madminer             INFO    ------------------------------------------------------------------------\n",
       "11:18 madminer             INFO    |                                                                      |\n",
-      "11:18 madminer             INFO    |  MadMiner v0.7.0                                                     |\n",
+      "11:18 madminer             INFO    |  MadMiner v0.7.4                                                     |\n",
       "11:18 madminer             INFO    |                                                                      |\n",
       "11:18 madminer             INFO    |         Johann Brehmer, Felix Kling, Irina Espejo, and Kyle Cranmer  |\n",
       "11:18 madminer             INFO    |                                                                      |\n",

--- a/examples/tutorial_particle_physics/3b_score.ipynb
+++ b/examples/tutorial_particle_physics/3b_score.ipynb
@@ -78,7 +78,7 @@
       "11:19 madminer             INFO    \n",
       "11:19 madminer             INFO    ------------------------------------------------------------------------\n",
       "11:19 madminer             INFO    |                                                                      |\n",
-      "11:19 madminer             INFO    |  MadMiner v0.7.0                                                     |\n",
+      "11:19 madminer             INFO    |  MadMiner v0.7.4                                                     |\n",
       "11:19 madminer             INFO    |                                                                      |\n",
       "11:19 madminer             INFO    |         Johann Brehmer, Felix Kling, Irina Espejo, and Kyle Cranmer  |\n",
       "11:19 madminer             INFO    |                                                                      |\n",

--- a/examples/tutorial_particle_physics/3c_likelihood.ipynb
+++ b/examples/tutorial_particle_physics/3c_likelihood.ipynb
@@ -71,7 +71,7 @@
       "11:20 madminer             INFO    \n",
       "11:20 madminer             INFO    ------------------------------------------------------------------------\n",
       "11:20 madminer             INFO    |                                                                      |\n",
-      "11:20 madminer             INFO    |  MadMiner v0.7.0                                                     |\n",
+      "11:20 madminer             INFO    |  MadMiner v0.7.4                                                     |\n",
       "11:20 madminer             INFO    |                                                                      |\n",
       "11:20 madminer             INFO    |         Johann Brehmer, Felix Kling, Irina Espejo, and Kyle Cranmer  |\n",
       "11:20 madminer             INFO    |                                                                      |\n",

--- a/examples/tutorial_particle_physics/4a_limits.ipynb
+++ b/examples/tutorial_particle_physics/4a_limits.ipynb
@@ -73,7 +73,7 @@
       "11:20 madminer             INFO    \n",
       "11:20 madminer             INFO    ------------------------------------------------------------------------\n",
       "11:20 madminer             INFO    |                                                                      |\n",
-      "11:20 madminer             INFO    |  MadMiner v0.7.0                                                     |\n",
+      "11:20 madminer             INFO    |  MadMiner v0.7.4                                                     |\n",
       "11:20 madminer             INFO    |                                                                      |\n",
       "11:20 madminer             INFO    |         Johann Brehmer, Felix Kling, Irina Espejo, and Kyle Cranmer  |\n",
       "11:20 madminer             INFO    |                                                                      |\n",

--- a/examples/tutorial_particle_physics/4b_fisher_information.ipynb
+++ b/examples/tutorial_particle_physics/4b_fisher_information.ipynb
@@ -65,7 +65,7 @@
       "11:21 madminer             INFO    \n",
       "11:21 madminer             INFO    ------------------------------------------------------------------------\n",
       "11:21 madminer             INFO    |                                                                      |\n",
-      "11:21 madminer             INFO    |  MadMiner v0.7.0                                                     |\n",
+      "11:21 madminer             INFO    |  MadMiner v0.7.4                                                     |\n",
       "11:21 madminer             INFO    |                                                                      |\n",
       "11:21 madminer             INFO    |         Johann Brehmer, Felix Kling, Irina Espejo, and Kyle Cranmer  |\n",
       "11:21 madminer             INFO    |                                                                      |\n",

--- a/examples/tutorial_particle_physics/4c_information_geometry.ipynb
+++ b/examples/tutorial_particle_physics/4c_information_geometry.ipynb
@@ -67,7 +67,7 @@
       "11:22 madminer             INFO    \n",
       "11:22 madminer             INFO    ------------------------------------------------------------------------\n",
       "11:22 madminer             INFO    |                                                                      |\n",
-      "11:22 madminer             INFO    |  MadMiner v0.7.0                                                     |\n",
+      "11:22 madminer             INFO    |  MadMiner v0.7.4                                                     |\n",
       "11:22 madminer             INFO    |                                                                      |\n",
       "11:22 madminer             INFO    |         Johann Brehmer, Felix Kling, Irina Espejo, and Kyle Cranmer  |\n",
       "11:22 madminer             INFO    |                                                                      |\n",

--- a/examples/tutorial_particle_physics/A1_systematic_uncertainties.ipynb
+++ b/examples/tutorial_particle_physics/A1_systematic_uncertainties.ipynb
@@ -68,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mg_dir = '/Users/johannbrehmer/work/projects/madminer/MG5_aMC_v2_6_4'"
+    "mg_dir = '/Users/johannbrehmer/work/projects/madminer/MG5_aMC_v2_6_7'"
    ]
   },
   {


### PR DESCRIPTION
This PR updates the [particle_physics](https://github.com/diana-hep/madminer/tree/master/examples/tutorial_particle_physics) tutorial Jupyter notebooks  within the `examples` folder, by:

- Updating the logged version of the package (now `0.7.4`).
- Updating the path to where MadGraph 5 is installed (check [its env. Dockerfile](https://github.com/scailfin/madminer-jupyter-env/blob/master/Dockerfile#L37) and [this similar PR](https://github.com/cranmer/madminer-tutorial/pull/2)).
- Updating the MadGraph folder version to `2.6.7`

---

Most of the changes are aesthetic, but for the MadGraph path one. If that is not changed the tutorial will not work.