### PR TITLE
addition of order; Reading NLO lhe files

### DIFF
--- a/madminer/core/madminer.py
+++ b/madminer/core/madminer.py
@@ -668,6 +668,7 @@ class MadMiner:
         initial_command=None,
         python2_override=False,
         systematics=None,
+		order='LO',
     ):
 
         """
@@ -775,6 +776,7 @@ class MadMiner:
             initial_command=initial_command,
             python2_override=python2_override,
             systematics=systematics,
+			order=order,
         )
 
     def run_multiple(
@@ -795,6 +797,7 @@ class MadMiner:
         initial_command=None,
         python2_override=False,
         systematics=None,
+		order='LO',
     ):
 
         """
@@ -984,6 +987,7 @@ class MadMiner:
                         template_filename=run_card_file,
                         run_card_filename=mg_process_directory + "/" + new_run_card_file,
                         systematics=systematics_used,
+						order=order,
                     )
 
                 # Copy Pythia card
@@ -1010,6 +1014,7 @@ class MadMiner:
                         log_dir=log_directory,
                         log_file_from_logdir=log_file_run,
                         explicit_python_call=python2_override,
+                        order=order,
                     )
                     mg_scripts.append(mg_script)
                 else:
@@ -1026,6 +1031,7 @@ class MadMiner:
                         initial_command=initial_command,
                         log_file=log_directory + "/" + log_file_run,
                         explicit_python_call=python2_override,
+						order=order,
                     )
 
                 i += 1

--- a/madminer/core/madminer.py
+++ b/madminer/core/madminer.py
@@ -216,7 +216,9 @@ class MadMiner:
 
         # Default names
         if benchmark_name is None:
-            benchmark_name = "benchmark_" + str(len(self.benchmarks))
+            benchmark_name = "benchmark_" + str(len(self.benchmarks))	order : 'LO' or 'NLO', optional
+            Differentiates between LO and NLO order runs. Minor changes to writing, reading and naming cards.
+	    Default value: 'LO'
 
         # Check input
         if not isinstance(parameter_values, dict):
@@ -346,7 +348,9 @@ class MadMiner:
                 n_bases=n_bases,
                 fixed_benchmarks_from_madminer=self.benchmarks,
                 n_trials=n_trials,
-                n_test_thetas=n_test_thetas,
+                n_test_thetas=n_test_thetas,	order : 'LO' or 'NLO', optional
+            Differentiates between LO and NLO order runs. Minor changes to writing, reading and naming cards.
+	    Default value: 'LO'
             )
         else:
             n_predefined_benchmarks = 0
@@ -801,7 +805,7 @@ class MadMiner:
         initial_command=None,
         python2_override=False,
         systematics=None,
-		order='LO',
+	order='LO',
     ):
 
         """
@@ -875,7 +879,11 @@ class MadMiner:
 
         systematics : None or list of str, optional
             If list of str, defines which systematics are used for these runs.
-
+	    
+	order : 'LO' or 'NLO', optional
+            Differentiates between LO and NLO order runs. Minor changes to writing, reading and naming cards.
+	    Default value: 'LO'
+	    
         Returns
         -------
             None

--- a/madminer/core/madminer.py
+++ b/madminer/core/madminer.py
@@ -216,9 +216,7 @@ class MadMiner:
 
         # Default names
         if benchmark_name is None:
-            benchmark_name = "benchmark_" + str(len(self.benchmarks))	order : 'LO' or 'NLO', optional
-            Differentiates between LO and NLO order runs. Minor changes to writing, reading and naming cards.
-	    Default value: 'LO'
+            benchmark_name = "benchmark_" + str(len(self.benchmarks))
 
         # Check input
         if not isinstance(parameter_values, dict):
@@ -348,9 +346,7 @@ class MadMiner:
                 n_bases=n_bases,
                 fixed_benchmarks_from_madminer=self.benchmarks,
                 n_trials=n_trials,
-                n_test_thetas=n_test_thetas,	order : 'LO' or 'NLO', optional
-            Differentiates between LO and NLO order runs. Minor changes to writing, reading and naming cards.
-	    Default value: 'LO'
+                n_test_thetas=n_test_thetas,
             )
         else:
             n_predefined_benchmarks = 0
@@ -784,7 +780,7 @@ class MadMiner:
             initial_command=initial_command,
             python2_override=python2_override,
             systematics=systematics,
-			order=order,
+            order=order,
         )
 
     def run_multiple(
@@ -1043,7 +1039,7 @@ class MadMiner:
                         initial_command=initial_command,
                         log_file=log_directory + "/" + log_file_run,
                         explicit_python_call=python2_override,
-						order=order,
+                        order=order,
                     )
 
                 i += 1

--- a/madminer/core/madminer.py
+++ b/madminer/core/madminer.py
@@ -668,7 +668,7 @@ class MadMiner:
         initial_command=None,
         python2_override=False,
         systematics=None,
-		order='LO',
+	order='LO',
     ):
 
         """
@@ -749,6 +749,10 @@ class MadMiner:
 
         systematics : None or list of str, optional
             If list of str, defines which systematics are used for this run.
+	 
+	order : 'LO' or 'NLO', optional
+            Differentiates between LO and NLO order runs. Minor changes to writing, reading and naming cards.
+	    Default value: 'LO'
 
         Returns
         -------

--- a/madminer/utils/interfaces/lhe.py
+++ b/madminer/utils/interfaces/lhe.py
@@ -710,7 +710,8 @@ def _parse_xml_event(event, sampling_benchmark):
         if len(elements) < 10:
             continue
         status = int(elements[1])
-
+        if elements[0] == '#aMCatNLO':
+            elements=elements[1:]
         if status == 1:
             pdgid = int(elements[0])
             px = float(elements[6])

--- a/madminer/utils/interfaces/mg.py
+++ b/madminer/utils/interfaces/mg.py
@@ -100,6 +100,7 @@ def setup_mg_with_scripts(
     log_dir=None,
     log_file_from_logdir=None,
     explicit_python_call=False,
+    order='LO',
 ):
     """
     Prepares a bash script that will start the event generation.
@@ -247,12 +248,19 @@ def setup_mg_with_scripts(
             mg_process_directory_placeholder,
             "/Cards/reweight_card.dat",
         )
-    if pythia8_card_file_from_mgprocdir is not None:
+    if pythia8_card_file_from_mgprocdir is not None and order == 'LO':
         copy_commands += "cp {}/{} {}{}\n".format(
             mg_process_directory_placeholder,
             pythia8_card_file_from_mgprocdir,
             mg_process_directory_placeholder,
             "/Cards/pythia8_card.dat",
+        )
+    elif pythia8_card_file_from_mgprocdir is not None and order == 'NLO':
+        copy_commands += "cp {}/{} {}{}\n".format(
+            mg_process_directory_placeholder,
+            pythia8_card_file_from_mgprocdir,
+            mg_process_directory_placeholder,
+            "/Cards/shower_card.dat",
         )
 
     if configuration_file_from_mgprocdir is not None:
@@ -321,6 +329,7 @@ def run_mg(
     initial_command=None,
     log_file=None,
     explicit_python_call=False,
+	order='LO',
 ):
     """
     Calls MadGraph to generate events.
@@ -392,8 +401,10 @@ def run_mg(
         shutil.copyfile(param_card_file, mg_process_directory + "/Cards/param_card.dat")
     if reweight_card_file is not None and not is_background:
         shutil.copyfile(reweight_card_file, mg_process_directory + "/Cards/reweight_card.dat")
-    if pythia8_card_file is not None:
+    if pythia8_card_file is not None and order=='LO':
         shutil.copyfile(pythia8_card_file, mg_process_directory + "/Cards/pythia8_card.dat")
+    if pythia8_card_file is not None and order=='NLO':
+        shutil.copyfile(pythia8_card_file, mg_process_directory + "/Cards/shower_card.dat")
     if configuration_card_file is not None:
         shutil.copyfile(configuration_card_file, mg_process_directory + "/Cards/me5_configuration.txt")
 

--- a/madminer/utils/interfaces/mg_cards.py
+++ b/madminer/utils/interfaces/mg_cards.py
@@ -129,7 +129,7 @@ def export_reweight_card(sample_benchmark, benchmarks, parameters, mg_process_di
         file.write(reweight_card)
 
 
-def export_run_card(template_filename, run_card_filename, systematics=None):
+def export_run_card(template_filename, run_card_filename, systematics=None, order='LO'):
     # Open parameter card template
     with open(template_filename) as file:
         run_card_template = file.read()
@@ -186,13 +186,14 @@ def export_run_card(template_filename, run_card_filename, systematics=None):
             continue
 
     # Add new entries - sytematics
-    run_card_lines.append("")
-    run_card_lines.append("#*********************************************************************")
-    run_card_lines.append("# MadMiner systematics setup                                         *")
-    run_card_lines.append("#*********************************************************************")
-    for key, value in six.iteritems(settings):
-        run_card_lines.append("{} = {}".format(value, key))
-    run_card_lines.append("")
+    if order=='LO':
+        run_card_lines.append("")
+        run_card_lines.append("#*********************************************************************")
+        run_card_lines.append("# MadMiner systematics setup                                         *")
+        run_card_lines.append("#*********************************************************************")
+        for key, value in six.iteritems(settings):
+            run_card_lines.append("{} = {}".format(value, key))
+        run_card_lines.append("")
 
     # Write new run card
     new_run_card = "\n".join(run_card_lines)


### PR DESCRIPTION
Hi,

I've added an `order` setting to accommodate differences between LO and NLO computations.
The changes are as follows:

* Removes the `use_syst` option from the run card at NLO
* Pythia card is named `shower_card.dat` at NLO
* At NLO, in lhe files there is an additional line starting with `#aMCatNLO`
  * I think this line does not contain particles and maybe a better way would be to skip this line entirely, but for now it checks the "status"

Hopefully, this `order` setting is useful in the future as well!