### PR TITLE
Bound dependency versions

### DIFF
--- a/madminer/__info__.py
+++ b/madminer/__info__.py
@@ -1,3 +1,3 @@
 __authors__ = ", ".join(["Johann Brehmer", "Felix Kling", "Irina Espejo", "Sinclert Perez", "Kyle Cranmer"])
 
-__version__ = "0.7.6"
+__version__ = "0.7.7"

--- a/madminer/utils/interfaces/delphes_root.py
+++ b/madminer/utils/interfaces/delphes_root.py
@@ -3,7 +3,7 @@ import six
 
 import numpy as np
 from collections import OrderedDict
-import uproot
+import uproot3
 import os
 import logging
 
@@ -42,7 +42,7 @@ def parse_delphes_root_file(
         logger.debug("Extracting weights %s", weight_labels)
 
     # Delphes ROOT file
-    root_file = uproot.open(str(delphes_sample_file))
+    root_file = uproot3.open(str(delphes_sample_file))
     # The str() call is important when using numpy 1.16.0 and Python 2.7. In this combination of versions, a unicode
     # delphes_sample_file would lead to a crash.
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ REQUIRED = [
     "scikit-hep>=0.5.0, <0.6.0",
     "six",
     "torch>=1.0.0",
-    "uproot",
+    "uproot>=3.11.0,<4.0.0",
 ]
 
 EXTRAS_DOCS = sorted(

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ REQUIRED = [
     "scikit-hep>=0.5.0, <0.6.0",
     "six",
     "torch>=1.0.0",
-    "uproot>=3.11.0,<4.0.0",
+    "uproot3>=3.14.1",
 ]
 
 EXTRAS_DOCS = sorted(


### PR DESCRIPTION
This PR addresses issue https://github.com/diana-hep/madminer/issues/453 by setting **lower / upper bounds** to the set of [setup.py](https://github.com/diana-hep/madminer/blob/master/setup.py#L36-L46) unbounded dependencies.

The most immediate problem to address is the recent incompatibility with the newest version of [uproot](https://uproot.readthedocs.io/en/latest/) (`uproot4`), which **breaks** some of the public methods / attributes being used within the [madminer/utils/interfaces/delphes_root.py](https://github.com/diana-hep/madminer/blob/master/madminer/utils/interfaces/delphes_root.py) module (check the list of [uproot4 removed features](https://uproot.readthedocs.io/en/latest/uproot3-to-4.html#removed-features)).

### Additional changes:
- Bump up package version to `0.7.7`.

### Notes
Additional dependency boundaries may be added. Please free to comment below for others to be considered.