### PR TITLE
Replace scikit-hep by vector pkg

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,14 +5,13 @@ channels:
 - defaults
 dependencies:
 - python=3.6.*
+- h5py
 - matplotlib>=2.0.0
 - numpy>=1.13.0
-- h5py
 - scipy>=1.0.0
-- scikit-learn>=0.19.0
 - pytorch>=1.0.0
 - pytest
 - pip
 - pip:
-  - uproot
-  - scikit-hep>=0.5.0, <0.6.0
+  - uproot3>=3.14.1
+  - vector>=0.8.0

--- a/madminer/__info__.py
+++ b/madminer/__info__.py
@@ -1,3 +1,9 @@
-__authors__ = ", ".join(["Johann Brehmer", "Felix Kling", "Irina Espejo", "Sinclert Perez", "Kyle Cranmer"])
+__authors__ = ", ".join([
+    "Johann Brehmer",
+    "Felix Kling",
+    "Irina Espejo",
+    "Sinclert Perez",
+    "Kyle Cranmer",
+])
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/madminer/utils/interfaces/delphes_root.py
+++ b/madminer/utils/interfaces/delphes_root.py
@@ -112,7 +112,7 @@ def parse_delphes_root_file(
                 "met": met_all_events[ievent][0],
                 "visible": visible_momentum,
                 "all": all_momentum,
-                "boost_to_com": lambda momentum: momentum.boost(all_momentum.boost_vector()),
+                "boost_to_com": lambda momentum: momentum.boost(all_momentum.to_Vector3D()),
             }
         )
 
@@ -269,7 +269,7 @@ def _get_particles_truth(tree, pt_min, eta_max, included_pdgids=None):
                 continue
 
             particle = MadMinerParticle()
-            particle.setptetaphie(pt, eta, phi, e)
+            particle.from_rhophietat(pt, phi, eta, e)
             particle.set_pdgid(pdgid)
             event_particles.append(particle)
 
@@ -299,7 +299,7 @@ def _get_particles_charged(tree, name, mass, pdgid_positive_charge, pt_min, eta_
             pdgid = pdgid_positive_charge if charge >= 0.0 else -pdgid_positive_charge
 
             particle = MadMinerParticle()
-            particle.setptetaphim(pt, eta, phi, mass)
+            particle.from_rhophietatau(pt, phi, eta, mass)
             particle.set_pdgid(pdgid)
             event_particles.append(particle)
 
@@ -363,7 +363,7 @@ def _get_particles_leptons(tree, pt_min_e, eta_max_e, pt_min_mu, eta_max_mu):
                 continue
 
             particle = MadMinerParticle()
-            particle.setptetaphim(pt, eta, phi, mass)
+            particle.from_rhophietatau(pt, phi, eta, mass)
             particle.set_pdgid(pdgid)
             event_particles.append(particle)
 
@@ -398,7 +398,7 @@ def _get_particles_truth_leptons(tree, pt_min_e, eta_max_e, pt_min_mu, eta_max_m
                 continue
 
             particle = MadMinerParticle()
-            particle.setptetaphie(pt, eta, phi, e)
+            particle.from_rhophietat(pt, phi, eta, e)
             particle.set_pdgid(pdgid)
             event_particles.append(particle)
 
@@ -426,7 +426,7 @@ def _get_particles_photons(tree, pt_min, eta_max):
                 continue
 
             particle = MadMinerParticle()
-            particle.setptetaphie(pt, eta, phi, e)
+            particle.from_rhophietat(pt, phi, eta, e)
             particle.set_pdgid(22)
             event_particles.append(particle)
 
@@ -466,7 +466,7 @@ def _get_particles_jets(tree, pt_min, eta_max):
                 continue
 
             particle = MadMinerParticle()
-            particle.setptetaphim(pt, eta, phi, mass)
+            particle.from_rhophietatau(pt, phi, eta, mass)
             particle.set_pdgid(9)
             particle.set_tags(tau_tag >= 1, b_tag >= 1, False)
             event_particles.append(particle)
@@ -507,7 +507,7 @@ def _get_particles_truth_jets(tree, pt_min, eta_max):
                 continue
 
             particle = MadMinerParticle()
-            particle.setptetaphim(pt, eta, phi, mass)
+            particle.from_rhophietatau(pt, phi, eta, mass)
             particle.set_pdgid(9)
             particle.set_tags(tau_tag >= 1, b_tag >= 1, False)
             event_particles.append(particle)
@@ -528,7 +528,7 @@ def _get_particles_truth_met(tree):
 
         for met, phi in zip(mets[ievent], phis[ievent]):
             particle = MadMinerParticle()
-            particle.setptetaphim(met, 0.0, phi, 0.0)
+            particle.from_rhophietatau(met, phi, 0.0, 0.0)
             particle.set_pdgid(0)
             event_particles.append(particle)
 
@@ -548,7 +548,7 @@ def _get_particles_met(tree):
 
         for met, phi in zip(mets[ievent], phis[ievent]):
             particle = MadMinerParticle()
-            particle.setptetaphim(met, 0.0, phi, 0.0)
+            particle.from_rhophietatau(met, phi, 0.0, 0.0)
             particle.set_pdgid(0)
             event_particles.append(particle)
 

--- a/madminer/utils/interfaces/lhe.py
+++ b/madminer/utils/interfaces/lhe.py
@@ -744,7 +744,7 @@ def _parse_xml_event(event, sampling_benchmark):
             e = float(elements[9])
             spin = float(elements[12])
             particle = MadMinerParticle()
-            particle.setpxpypze(px, py, pz, e)
+            particle.from_xyzt(px, py, pz, e)
             particle.set_pdgid(pdgid)
             particle.set_spin(spin)
             particles.append(particle)
@@ -854,7 +854,7 @@ def _parse_txt_events(filename, sampling_benchmark):
                     e = float(elements[9])
                     spin = float(elements[12])
                     particle = MadMinerParticle()
-                    particle.setpxpypze(px, py, pz, e)
+                    particle.from_xyzt(px, py, pz, e)
                     particle.set_pdgid(pdgid)
                     particle.set_spin(spin)
                     particles.append(particle)
@@ -945,7 +945,7 @@ def _get_objects(particles, particles_truth, met_resolution=None, global_event_d
     # Sum over all particles
     ht = 0.0
     visible_sum = MadMinerParticle()
-    visible_sum.setpxpypze(0.0, 0.0, 0.0, 0.0)
+    visible_sum.from_xyzt(0.0, 0.0, 0.0, 0.0)
 
     for particle in particles:
         pdgid = abs(particle.pdgid)
@@ -963,10 +963,10 @@ def _get_objects(particles, particles_truth, met_resolution=None, global_event_d
         noise_y = 0.0
 
     # MET
-    met_x = -visible_sum.px + noise_x
-    met_y = -visible_sum.py + noise_y
+    met_x = -visible_sum.x + noise_x
+    met_y = -visible_sum.y + noise_y
     met = MadMinerParticle()
-    met.setpxpypze(met_x, met_y, 0.0, (met_x ** 2 + met_y ** 2) ** 0.5)
+    met.from_xyzt(met_x, met_y, 0.0, (met_x ** 2 + met_y ** 2) ** 0.5)
 
     # Build objects
     objects = math_commands()
@@ -1059,7 +1059,7 @@ def _smear_particles(particles, energy_resolutions, pt_resolutions, eta_resoluti
 
         if None in energy_resolutions[pdgid]:
             # Calculate E from on-shell conditions
-            smeared_particle.setptetaphim(pt, eta, phi, particle.m)
+            smeared_particle.from_rhophietatau(pt, phi, eta, particle.m)
 
         elif None in pt_resolutions[pdgid]:
             # Calculate pT from on-shell conditions
@@ -1067,11 +1067,11 @@ def _smear_particles(particles, energy_resolutions, pt_resolutions, eta_resoluti
                 pt = (e ** 2 - m ** 2) ** 0.5 / np.cosh(eta)
             else:
                 pt = 0.0
-            smeared_particle.setptetaphie(pt, eta, phi, e)
+            smeared_particle.from_rhophietat(pt, phi, eta, e)
 
         else:
             # Everything smeared manually
-            smeared_particle.setptetaphie(pt, eta, phi, e)
+            smeared_particle.from_rhophietat(pt, phi, eta, e)
 
         # PDG id (also sets charge)
         smeared_particle.set_pdgid(pdgid)

--- a/madminer/utils/particle.py
+++ b/madminer/utils/particle.py
@@ -1,10 +1,10 @@
 import logging
-from skhep.math.vectors import LorentzVector
+import vector
 
 logger = logging.getLogger(__name__)
 
 
-class MadMinerParticle(LorentzVector):
+class MadMinerParticle(vector.VectorObject4D):
     """ """
 
     def __init__(self, *args, **kwargs):
@@ -50,6 +50,7 @@ class MadMinerParticle(LorentzVector):
         self.spin = spin
 
     def __iadd__(self, other):
+        assert isinstance(other, self.__class__)
         super(MadMinerParticle, self).__iadd__(other)
         self.charge = None if self.charge is None or other.charge is None else self.charge + other.charge
         self.pdgid = None
@@ -60,6 +61,7 @@ class MadMinerParticle(LorentzVector):
         return self
 
     def __isub__(self, other):
+        assert isinstance(other, self.__class__)
         super(MadMinerParticle, self).__isub__(other)
         self.charge = None if self.charge is None or other.charge is None else self.charge - other.charge
         self.pdgid = None
@@ -73,6 +75,7 @@ class MadMinerParticle(LorentzVector):
         return self
 
     def __add__(self, other):
+        assert isinstance(other, self.__class__)
         vec = super(MadMinerParticle, self).__add__(other)
         vec.charge = None if self.charge is None or other.charge is None else self.charge + other.charge
         vec.pdgid = None
@@ -83,6 +86,7 @@ class MadMinerParticle(LorentzVector):
         return vec
 
     def __sub__(self, other):
+        assert isinstance(other, self.__class__)
         vec = super(MadMinerParticle, self).__sub__(other)
         vec.charge = None if self.charge is None or other.charge is None else self.charge - other.charge
         vec.pdgid = None
@@ -95,7 +99,7 @@ class MadMinerParticle(LorentzVector):
     def boost(self, *args):
         vec = super(MadMinerParticle, self).boost(*args)
 
-        particle = MadMinerParticle().from4vector(vec)
+        particle = MadMinerParticle().from_xyzt(vec.x, vec.y, vec.z, vec.t)
         particle.charge = self.charge
         particle.spin = self.spin
         particle.pdgid = self.pdgid

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,9 @@ REQUIRED = [
     "matplotlib>=2.0.0",
     "numpy>=1.13.0",
     "scipy>=1.0.0",
-    "scikit-hep>=0.5.0, <0.6.0",
     "torch>=1.0.0",
     "uproot3>=3.14.1",
+    "vector>=0.8.0",
 ]
 
 EXTRAS_DOCS = [


### PR DESCRIPTION
This PR replaces the unnecessary [scikit-hep](https://github.com/scikit-hep/scikit-hep) dependency (from which MadMiner one uses a tiny part), by the [vector](https://github.com/scikit-hep/vector) package, independently installable from PyPi. In addition to reducing the dependencies _surface_, this change allows the project to make use of the latest versions of `vector`, instead of being stuck at the `<0.6.0` versions of `scikit-hep`.


### Refactor procedure
The refactor has been done making use of `vector.Lorentz` wrapping class: [`VectorObject4D`](https://github.com/scikit-hep/vector/blob/main/src/vector/_backends/object_.py#L921). This class gives us the right abstractions to make direct substitutions for the legacy `skhep.math.vector.LorentzVector` methods.

After the main refactor of the `MadminerParticle` class, its uses has been found through the _"Find Usages"_ PyCharm tool, finding occurrences at:
- [madminer/utils/interfaces/delphes_root.py](https://github.com/diana-hep/madminer/blob/master/madminer/utils/interfaces/delphes_root.py).
- [madminer/utils/interfaces/lhe.py](https://github.com/diana-hep/madminer/blob/master/madminer/utils/interfaces/lhe.py).


### Substitutions
Given my limited Physics background, I have made some direct substitutions that need to be checked.

- `skhep.math.vector.LorentzVector.from4vector` -> `vector.VectorObject4D.from_xyzt`
- `skhep.math.vector.LorentzVector.setptetaphie` -> `vector.VectorObject4D.from_rhophietat`
- `skhep.math.vector.LorentzVector.setptetaphim` -> `vector.VectorObject4D.from_rhophietatau`

⚠️  There was an additional substitution which I am unsure of, which is the one affecting `boost_vector`. I could only find a property called [boostvector](https://github.com/scikit-hep/scikit-hep/blob/0.5.1/skhep/math/vectors.py#L806-L809) on Scikit-hep, returning a 3D vector. Therefore, I assumed the equivalent would be [to_vector3D](https://github.com/scikit-hep/vector/blob/main/src/vector/_methods.py#L178):

- `skhep.math.vector.LorentzVector.boost_vector` -> `vector.VectorObject4D.to_Vector3D`

---

Just in case you could take a look, cc @jpivarski @henryiii 