### PR TITLE
Define read-the-docs config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,23 @@
+# Read the Docs configuration file
+# Ref: https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats:
+  - html
+
+# Equivalent to:
+# $ python -m pip install .[docs]
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs


### PR DESCRIPTION
This PR is supposed to fix the [read-the-docs](https://readthedocs.org/) building process, which has been broken since July 1st 2020 ([check here](https://readthedocs.org/projects/madminer/builds/)).

The problem seems to be the missing installation of `numpydoc`, which has been perfectly declared in [the setup.py `docs` section](https://github.com/diana-hep/madminer/blob/master/setup.py#L49) for a long time now. Therefore, my intuition tells me that the _read-the-docs_ folks changed the build process at some point during the last year, requiring a `.readthedocs.yml` file to be declared now.