### PR TITLE
Docs: replace recommonmark by MyST

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,10 +42,10 @@ release = version
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
+    'myst_parser',
+    'numpydoc',
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
-    'numpydoc',
-    #'recommonmark',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -55,13 +55,6 @@ templates_path = ['_templates']
 # You can specify multiple suffix as a list of string:
 #
 source_suffix = ['.rst', '.md']
-
-# Markdown support
-from recommonmark.parser import CommonMarkParser
-
-source_parsers = {
-    '.md': CommonMarkParser,
-}
 
 # The master toctree document.
 master_doc = 'index'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,6 @@ MadMiner
    madminer.likelihood
    madminer.limits
    madminer.ml
-   madminer.morphing
    madminer.plotting
    madminer.sampling
 

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,7 +1,0 @@
-madminer
-========
-
-.. toctree::
-   :maxdepth: 4
-
-   madminer

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,8 @@ REQUIRED = [
 ]
 
 EXTRAS_DOCS = [
+    "myst-parser",
     "numpydoc",
-    "recommonmark",
     "sphinx>=1.4",
     "sphinx_rtd_theme",
 ]

--- a/setup.py
+++ b/setup.py
@@ -44,25 +44,22 @@ REQUIRED = [
     "uproot3>=3.14.1",
 ]
 
-EXTRAS_DOCS = sorted(
-    [
-        "numpydoc",
-        "recommonmark",
-        "sphinx>=1.4",
-        "sphinx_rtd_theme",
-    ]
-)
-EXTRAS_TEST = sorted(
-    EXTRAS_DOCS + [
-        "pytest",
-    ]
-)
-EXTRAS_EXAMPLES = sorted(
-    [
-        "bqplot",
-        "pandas",
-    ]
-)
+EXTRAS_DOCS = [
+    "numpydoc",
+    "recommonmark",
+    "sphinx>=1.4",
+    "sphinx_rtd_theme",
+]
+
+EXTRAS_TEST = [
+    *EXTRAS_DOCS,
+    "pytest",
+]
+
+EXTRAS_EXAMPLES = [
+    "bqplot",
+    "pandas",
+]
 
 
 class UploadCommand(Command):


### PR DESCRIPTION
This PR replaces the legacy [readthedocs/recommonmark](https://github.com/readthedocs/recommonmark) package by its direct substitution: [executablebooks/MyST-Parser](https://github.com/executablebooks/MyST-Parser). For more information about `recommonmark` deprecation and MyST adoption, check [this issue](https://github.com/readthedocs/recommonmark/issues/221).