### PR TITLE
Fix benchmark array dict_values

### DIFF
--- a/madminer/analysis/dataanalyzer.py
+++ b/madminer/analysis/dataanalyzer.py
@@ -973,5 +973,5 @@ class DataAnalyzer(object):
 
     def _benchmark_array(self):
         return np.asarray([
-            benchmark.values() for benchmark in self.benchmarks.values()
+            list(benchmark.values()) for benchmark in self.benchmarks.values()
         ])


### PR DESCRIPTION
This PR addresses issue https://github.com/diana-hep/madminer/issues/459 where dictionary values were being injected into a Numpy array as `dict_values` type, instead of their actual type. The fix will be included in the upcoming `0.8.1` release.