### PR TITLE
Fix GHA PyPi-publish version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,7 @@ jobs:
           --outdir dist \
           .
     - name: "Publish Python package"
-      uses: pypa/gh-action-pypi-publish@v1.4
+      uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This PR fixes the pinned version of the [publish.yml](https://github.com/diana-hep/madminer/blob/master/.github/workflows/publish.yml) GHA workflow.

GHA PyPi-publish releases: https://github.com/pypa/gh-action-pypi-publish/releases