### PR TITLE
Strip URLs out of the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,35 @@
-# MadMiner: Machine learning–based inference for particle physics
+# MadMiner: ML based inference for particle physics
 
 **By Johann Brehmer, Felix Kling, Irina Espejo, Sinclert Pérez, and Kyle Cranmer**
 
-[![PyPI version](https://badge.fury.io/py/madminer.svg)](https://badge.fury.io/py/madminer)
-[![CI Status](https://github.com/diana-hep/madminer/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/diana-hep/madminer/actions/workflows/ci.yml?query=branch%3Amaster)
-[![Documentation Status](https://readthedocs.org/projects/madminer/badge/?version=latest)](https://madminer.readthedocs.io/en/latest/?badge=latest)
-[![Gitter](https://badges.gitter.im/madminer/community.svg)](https://gitter.im/madminer/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1489147.svg)](https://doi.org/10.5281/zenodo.1489147)
-[![arXiv](http://img.shields.io/badge/arXiv-1907.10621-B31B1B.svg)](https://arxiv.org/abs/1907.10621)
+[![PyPI version][pypi-version-badge]][pypi-version-link]
+[![CI/CD Status][ci-status-badge]][ci-status-link]
+[![Docs Status][docs-status-badge]][docs-status-link]
+[![Gitter chat][chat-gitter-badge]][chat-gitter-link]
+[![Code style][code-style-badge]][code-style-link]
+[![MIT license][mit-license-badge]][mit-license-link]
+[![DOI reference][ref-zenodo-badge]][ref-zenodo-link]
+[![ArXiv reference][ref-arxiv-badge]][ref-arxiv-link]
 
 
 ## Introduction
 
-![Schematics of the simulation and inference workflow](docs/img/rascal-explainer.png)
+![Schematics of the simulation and inference workflow][image-rascal-diagram]
 
 Particle physics processes are usually modeled with complex Monte-Carlo simulations of the hard process, parton shower,
 and detector interactions. These simulators typically do not admit a tractable likelihood function: given a (potentially
 high-dimensional) set of observables, it is usually not possible to calculate the probability of these observables
-for some model parameters. Particle physicisists usually tackle this problem of "likelihood-free inference" by
+for some model parameters. Particle physicists usually tackle this problem of "likelihood-free inference" by
 hand-picking a few "good" observables or summary statistics and filling histograms of them. But this conventional
 approach discards the information in all other observables and often does not scale well to high-dimensional problems.
 
-In the three publications
-["Constraining Effective Field Theories With Machine Learning"](https://arxiv.org/abs/1805.00013),
-["A Guide to Constraining Effective Field Theories With Machine Learning"](https://arxiv.org/abs/1805.00020), and
-["Mining gold from implicit models to improve likelihood-free inference"](https://arxiv.org/abs/1805.12244),
+In the three publications ["Constraining Effective Field Theories with Machine Learning"][ref-arxiv-madminer-1],
+["A Guide to Constraining Effective Field Theories with Machine Learning"][ref-arxiv-madminer-2], and
+["Mining gold from implicit models to improve likelihood-free inference"][ref-arxiv-madminer-3],
 a new approach has been developed. In a nutshell, additional information is extracted from the simulations that is
-closely related to the matrix elements that determine the hard process. This
-"augmented data" can be used to train neural networks to efficiently approximate arbitrary likelihood ratios. We
-playfully call this process "mining gold" from the simulator, since this information may be hard to get, but turns out
-to be very valuable for inference.
+closely related to the matrix elements that determine the hard process. This "augmented data" can be used to train
+neural networks to efficiently approximate arbitrary likelihood ratios. We playfully call this process "mining gold"
+from the simulator, since this information may be hard to get, but turns out to be very valuable for inference.
 
 But the gold does not have to be hard to mine: MadMiner automates these modern multivariate inference strategies. It
 wraps around the simulators MadGraph and Pythia, with different options for the detector simulation. It streamlines all
@@ -41,39 +39,28 @@ and evaluation of the neural networks, and the statistical analysis are implemen
 
 ## Resources
 
-
 ### Paper
-
-Our main publication [MadMiner: Machine-learning-based inference for particle physics](https://arxiv.org/abs/1907.10621)
+Our main publication [MadMiner: Machine-learning-based inference for particle physics][ref-arxiv-link]
 provides an overview over this package. We recommend reading it first before jumping into the code.
 
-
 ### Installation instructions
-
-Please have a look at our [installation instructions](https://madminer.readthedocs.io/en/latest/installation.html).
-
+Please have a look at our [installation instructions][docs-installation-guide].
 
 ### Tutorials
+In the [examples][examples-folder-path] folder in this repository, we provide two tutorials. The first is called
+[_Toy simulator_][examples-simulator-path], and it is based on a toy problem rather than a full particle-physics simulation.
+It demonstrates inference with MadMiner without spending much time on the more technical steps of running the simulation.
+The second, called [_Particle physics_][examples-physics-path], shows all steps of a particle-physics analysis with MadMiner.
 
-In the [examples](examples/) folder in this repository, we provide two tutorials. The first at
-[examples/tutorial_toy_simulator/tutorial_toy_simulator.ipynb](examples/tutorial_toy_simulator/tutorial_toy_simulator.ipynb)
-is based on a toy problem rather than a full particle-physics simulation. It demonstrates
-inference with MadMiner without spending much time on the more technical steps of running the simulation. The second,
-at [examples/tutorial_particle_physics](examples/tutorial_particle_physics), shows all steps of a particle-physics
-analysis with MadMiner.
-
-These examples are the basis of [an online tutorial](https://cranmer.github.io/madminer-tutorial/intro) built with on Jupyter Books. It also walks through how to run MadMiner using docker so that you don't have to install Fortran, MadGraph, Pythia, Delphes, etc. You can even run it with no install using binder. 
+These examples are the basis of [the online tutorial][jupyter-tutorial-link] built on Jupyter Books. It also walks
+through how to run MadMiner using Docker so that you do not have to install Fortran, MadGraph, Pythia, Delphes, etc.
+You can even run it with no install using Binder. 
 
 ### Documentation
-
-The madminer API is documented on [readthedocs](https://madminer.readthedocs.io/en/latest/?badge=latest).
-
+The madminer API is documented on [Read the Docs][docs-index].
 
 ### Support
-
-If you have any questions, please
-chat to us [in our Gitter community](https://gitter.im/madminer/community) or write us at 
-[johann.brehmer@nyu.edu](johann.brehmer@nyu.edu).
+If you have any questions, please chat to us in our [Gitter community][chat-gitter-link].
 
 
 ## Citations
@@ -81,10 +68,8 @@ chat to us [in our Gitter community](https://gitter.im/madminer/community) or wr
 If you use MadMiner, please cite our main publication,
 ```
 @article{Brehmer:2019xox,
-      author         = "Brehmer, Johann and Kling, Felix and Espejo, Irina and
-                        Cranmer, Kyle",
-      title          = "{MadMiner: Machine learning-based inference for particle
-                        physics}",
+      author         = "Brehmer, Johann and Kling, Felix and Espejo, Irina and Cranmer, Kyle",
+      title          = "{MadMiner: Machine learning-based inference for particle physics}",
       journal        = "Comput. Softw. Big Sci.",
       volume         = "4",
       year           = "2020",
@@ -110,23 +95,61 @@ The code itself can be cited as
 
 The main references for the implemented inference techniques are the following:
 
-- CARL: [1506.02169](https://arxiv.org/abs/1506.02169)
-- MAF: [1705.07057](https://arxiv.org/abs/1705.07057)
-- CASCAL, RASCAL, ROLR, SALLY, SALLINO, SCANDAL: [1805.00013](https://arxiv.org/abs/1805.00013), [1805.00020](https://arxiv.org/abs/1805.00020), [1805.12244](https://arxiv.org/abs/1805.12244)
-- ALICE, ALICES: [1808.00973](https://arxiv.org/abs/1808.00973)
+- CARL: [1506.02169][ref-arxiv-carl].
+- MAF: [1705.07057][ref-arxiv-maf].
+- CASCAL, RASCAL, ROLR, SALLY, SALLINO, SCANDAL:
+  - [1805.00013][ref-arxiv-madminer-1].
+  - [1805.00020][ref-arxiv-madminer-2].
+  - [1805.12244][ref-arxiv-madminer-3].
+- ALICE, ALICES: [1808.00973][ref-arxiv-alice].
 
 
 ## Acknowledgements
 
-We are immensely grateful to all [contributors](https://github.com/diana-hep/madminer/graphs/contributors) and bug reporters! 
-In particular, we would like to thank Zubair Bhatti, Philipp Englert, Lukas Heinrich, Alexander Held, Samuel Homiller,
-and Duccio Pappadopulo.
+We are immensely grateful to all [contributors][repo-madminer-contrib] and bug reporters! In particular, we would like
+to thank Zubair Bhatti, Philipp Englert, Lukas Heinrich, Alexander Held, Samuel Homiller and Duccio Pappadopulo.
 
-The SCANDAL inference method is based on [Masked Autoregressive Flows](https://arxiv.org/abs/1705.07057), and our
-implementation is a PyTorch port of the original code by George Papamakarios et al., which is available at
-[https://github.com/gpapamak/maf](https://github.com/gpapamak/maf). Our [setup.py](setup.py) was adapted from
-[https://github.com/kennethreitz/setup.py](https://github.com/kennethreitz/setup.py).
+The SCANDAL inference method is based on [Masked Autoregressive Flows][ref-arxiv-scandal], where our implementation is
+a PyTorch port of the original code by George Papamakarios, available at [this repository][repo-maf-main-page].
 
-![iris-hep logo](https://iris-hep.org/assets/logos/Iris-hep-4-no-long-name.png)
+![IRIS-HEP logo][image-iris-logo]
 
-We are grateful for the support of [iris-hep](https://iris-hep.org) and [diana-hep](https://diana-hep.org).
+We are grateful for the support of [IRIS-HEP][web-iris-hep] and [DIANA-HEP][web-diana-hep].
+
+
+[chat-gitter-badge]: https://badges.gitter.im/madminer/community.svg
+[chat-gitter-link]: https://gitter.im/madminer/community
+[ci-status-badge]: https://github.com/diana-hep/madminer/actions/workflows/ci.yml/badge.svg?branch=master
+[ci-status-link]: https://github.com/diana-hep/madminer/actions/workflows/ci.yml?query=branch%3Amaster
+[code-style-badge]: https://img.shields.io/badge/code%20style-black-000000.svg
+[code-style-link]: https://github.com/psf/black
+[docs-status-badge]: https://readthedocs.org/projects/madminer/badge/?version=latest
+[docs-status-link]: https://madminer.readthedocs.io/en/latest/?badge=latest
+[mit-license-badge]: https://img.shields.io/badge/License-MIT-blue.svg
+[mit-license-link]: https://github.com/diana-hep/madminer/blob/master/LICENSE.md
+[pypi-version-badge]: https://badge.fury.io/py/madminer.svg
+[pypi-version-link]: https://badge.fury.io/py/madminer
+[ref-arxiv-badge]: http://img.shields.io/badge/arXiv-1907.10621-B31B1B.svg
+[ref-arxiv-link]: https://arxiv.org/abs/1907.10621
+[ref-zenodo-badge]: https://zenodo.org/badge/DOI/10.5281/zenodo.1489147.svg
+[ref-zenodo-link]: https://doi.org/10.5281/zenodo.1489147
+
+[docs-index]: https://madminer.readthedocs.io/en/latest/
+[docs-installation-guide ]: https://madminer.readthedocs.io/en/latest/installation.html
+[examples-folder-path]: examples
+[examples-physics-path]: examples/tutorial_particle_physics
+[examples-simulator-path]: examples/tutorial_toy_simulator/tutorial_toy_simulator.ipynb
+[image-iris-logo]: https://iris-hep.org/assets/logos/Iris-hep-4-no-long-name.png
+[image-rascal-diagram]: docs/img/rascal-explainer.png
+[jupyter-tutorial-link]: https://cranmer.github.io/madminer-tutorial/intro
+[ref-arxiv-alice]: https://arxiv.org/abs/1808.00973
+[ref-arxiv-carl]: https://arxiv.org/abs/1506.02169
+[ref-arxiv-maf]: https://arxiv.org/abs/1705.07057
+[ref-arxiv-madminer-1]: https://arxiv.org/abs/1805.00013
+[ref-arxiv-madminer-2]: https://arxiv.org/abs/1805.00020
+[ref-arxiv-madminer-3]: https://arxiv.org/abs/1805.12244
+[ref-arxiv-scandal]: https://arxiv.org/abs/1705.07057
+[repo-madminer-contrib]: https://github.com/diana-hep/madminer/graphs/contributors
+[repo-maf-main-page]: https://github.com/gpapamak/maf
+[web-diana-hep]: https://diana-hep.org
+[web-iris-hep]: https://iris-hep.org

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,37 +3,43 @@
 ## Simulator dependencies
 
 Make sure the following tools are installed and running:
-- MadGraph (we've tested our setup with MG5_aMC v2.8.0+). See [https://launchpad.net/mg5amcnlo](https://launchpad.net/mg5amcnlo)
+- MadGraph (we have tested our setup with version 2.8.0+). See [MadGraph's website][web-madgraph-main-page]
   for installation instructions. Note that MadGraph requires a Fortran compiler as well as Python 3.6+.
-- For the analysis of systematic uncertainties, LHAPDF6 has to be installed with Python support (see also
-  [the documentation of MadGraph's systematics tool](https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics)).
+- For the analysis of systematic uncertainties, LHAPDF6 has to be installed with Python support
+  (see also [the documentation of MadGraph's systematics tool][web-madgraph-systematics]).
 
 For the detector simulation part, there are different options. For simple parton-level analyses, we provide a bare-bones
-option to calculate truth-level observables which do not require any additional packages.
-
-We have also implemented a fast detector simulation based on Delphes with a flexible framework to calculate observables.
+option to calculate truth-level observables which do not require any additional packages. We have also implemented
+a fast detector simulation based on Delphes with a flexible framework to calculate observables. 
 Using this adds additional requirements:
+
 - Pythia8 and the MG-Pythia interface, installed from within the MadGraph command line interface: execute
  `<MadGraph5_directory>/bin/mg5_aMC`, and then inside the MadGraph interface, run `install pythia8` and
  `install mg5amc_py8_interface`.
 - Delphes. Again, you can (but this time you don't have to) install it from the MadGraph command line interface with
   `install Delphes`.
-  
+
 Finally, Delphes can be replaced with another detector simulation, for instance a full detector simulation based
 with Geant4. In this case, the user has to implement code that runs the detector simulation, calculates the observables,
 and stores the observables and weights in the HDF5 file. The `DelphesProcessor` and `LHEProcessor` classes might provide
 some guidance for this.
 
+
 ## Install MadMiner
 
 To install the MadMiner package with all its Python dependencies, run `pip install madminer`.
 
-To get the latest development version as well as the tutorials, clone the
-[GitHub repository](https://github.com/diana-hep/madminer) and run `pip install -e .` from the repository main
-folder.
+To get the latest development version as well as the tutorials, clone the [GitHub repository][repo-madminer]
+and run `pip install -e .` from the repository main folder.
 
-### Docker image
 
-At [https://hub.docker.com/u/madminertool/](https://hub.docker.com/u/madminertool/) we provide Docker images for
-the latest version of MadMiner and the physics simulator. Please email [iem244@nyu.edu](mailto:iem244@nyu.edu) for any
-questions about the Docker images.
+## Docker image
+
+At the DockerHub [madminertool organization][docker-madminer] we provide Docker images for the latest version of MadMiner.
+Please email [Irina Espejo](mailto:iem244@nyu.edu) for any questions about the Docker images.
+
+
+[docker-madminer]: https://hub.docker.com/u/madminertool/
+[repo-madminer]: https://github.com/diana-hep/madminer
+[web-madgraph-main-page]: https://launchpad.net/mg5amcnlo
+[web-madgraph-systematics]: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,11 +13,10 @@ option to calculate truth-level observables which do not require any additional 
 a fast detector simulation based on Delphes with a flexible framework to calculate observables. 
 Using this adds additional requirements:
 
-- Pythia8 and the MG-Pythia interface, installed from within the MadGraph command line interface: execute
- `<MadGraph5_directory>/bin/mg5_aMC`, and then inside the MadGraph interface, run `install pythia8` and
- `install mg5amc_py8_interface`.
-- Delphes. Again, you can (but this time you don't have to) install it from the MadGraph command line interface with
-  `install Delphes`.
+```shell
+echo "install pythia8" | python3 <MadGraph_dir>/bin/mg5_aMC
+echo "install Delphes" | python3 <MadGraph_dir>/bin/mg5_aMC
+```
 
 Finally, Delphes can be replaced with another detector simulation, for instance a full detector simulation based
 with Geant4. In this case, the user has to implement code that runs the detector simulation, calculates the observables,

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -3,21 +3,24 @@
 Particle physics processes are usually modelled with complex Monte-Carlo simulations of the hard process, parton shower,
 and detector interactions. These simulators typically do not admit a tractable likelihood function: given a (potentially
 high-dimensional) set of observables, it is usually not possible to calculate the probability of these observables
-for some model parameters. Particle physicisists usually tackle this problem of "likelihood-free inference" by
+for some model parameters. Particle physicists usually tackle this problem of "likelihood-free inference" by
 hand-picking a few "good" observables or summary statistics and filling histograms of them. But this conventional
 approach discards the information in all other observables and often does not scale well to high-dimensional problems.
 
-In the three publications
-["Constraining Effective Field Theories With Machine Learning"](https://arxiv.org/abs/1805.00013),
-["A Guide to Constraining Effective Field Theories With Machine Learning"](https://arxiv.org/abs/1805.00020), and
-["Mining gold from implicit models to improve likelihood-free inference"](https://arxiv.org/abs/1805.12244),
-a new approach has been developed. In a nut shell, additional information is extracted from the simulations that is
-closely related to the matrix elements that determine the hard process. This
-"augmented data" can be used to train neural networks to efficiently approximate arbitrary likelihood ratios. We
-playfully call this process "mining gold" from the simulator, since this information may be hard to get, but turns out
-to be very valuable for inference.
+In the three publications ["Constraining Effective Field Theories with Machine Learning"][ref-arxiv-madminer-1],
+["A Guide to Constraining Effective Field Theories with Machine Learning"][ref-arxiv-madminer-2], and
+["Mining gold from implicit models to improve likelihood-free inference"][ref-arxiv-madminer-3],
+a new approach has been developed. In a nutshell, additional information is extracted from the simulations that is
+closely related to the matrix elements that determine the hard process. This "augmented data" can be used to train
+neural networks to efficiently approximate arbitrary likelihood ratios. We playfully call this process "mining gold"
+from the simulator, since this information may be hard to get, but turns out to be very valuable for inference.
 
 But the gold does not have to be hard to mine. This package automates these inference strategies. It wraps around the
 simulators MadGraph and Pythia, with different options for the detector simulation. All steps in the analysis chain from
 the simulation to the extraction of the augmented data, their processing, and the training and evaluation of the neural
 estimators are implemented.
+
+
+[ref-arxiv-madminer-1]: https://arxiv.org/abs/1805.00013
+[ref-arxiv-madminer-2]: https://arxiv.org/abs/1805.00020
+[ref-arxiv-madminer-3]: https://arxiv.org/abs/1805.12244

--- a/docs/references.md
+++ b/docs/references.md
@@ -5,10 +5,8 @@
 If you use MadMiner, please cite our main publication,
 ```
 @article{Brehmer:2019xox,
-      author         = "Brehmer, Johann and Kling, Felix and Espejo, Irina and
-                        Cranmer, Kyle",
-      title          = "{MadMiner: Machine learning-based inference for particle
-                        physics}",
+      author         = "Brehmer, Johann and Kling, Felix and Espejo, Irina and Cranmer, Kyle",
+      title          = "{MadMiner: Machine learning-based inference for particle physics}",
       journal        = "Comput. Softw. Big Sci.",
       volume         = "4",
       year           = "2020",
@@ -35,19 +33,30 @@ The code itself can be cited as
 
 The main references for the implemented inference techniques are the following:
 
-- CARL: [1506.02169](https://arxiv.org/abs/1506.02169)
-- MAF: [1705.07057](https://arxiv.org/abs/1705.07057)
-- CASCAL, RASCAL, ROLR, SALLY, SALLINO, SCANDAL: [1805.00013](https://arxiv.org/abs/1805.00013), [1805.00020](https://arxiv.org/abs/1805.00020), [1805.12244](https://arxiv.org/abs/1805.12244)
-- ALICE, ALICES: [1808.00973](https://arxiv.org/abs/1808.00973)
+- CARL: [1506.02169][ref-arxiv-carl].
+- MAF: [1705.07057][ref-arxiv-maf].
+- CASCAL, RASCAL, ROLR, SALLY, SALLINO, SCANDAL:
+  - [1805.00013][ref-arxiv-madminer-1].
+  - [1805.00020][ref-arxiv-madminer-2].
+  - [1805.12244][ref-arxiv-madminer-3].
+- ALICE, ALICES: [1808.00973][ref-arxiv-alice].
 
 
 ## Acknowledgements
 
-We are immensely grateful to all contributors and bug reporters! In particular, we would like to thank Zubair Bhatti,
-Philipp Englert, Lukas Heinrich, Alexander Held, Samuel Homiller, and Duccio Pappadopulo.
+We are immensely grateful to all [contributors][repo-madminer-contrib] and bug reporters! In particular, we would like
+to thank Zubair Bhatti, Philipp Englert, Lukas Heinrich, Alexander Held, Samuel Homiller and Duccio Pappadopulo.
 
-The SCANDAL inference method is based on [Masked Autoregressive Flows](https://arxiv.org/abs/1705.07057), and our
-implementation is a pyTorch port of the original code by George Papamakarios et al., which is available at
-[https://github.com/gpapamak/maf](https://github.com/gpapamak/maf).
+The SCANDAL inference method is based on [Masked Autoregressive Flows][ref-arxiv-scandal], where our implementation is
+a PyTorch port of the original code by George Papamakarios, available at [this repository][repo-maf-main-page].
 
-The `setup.py` was adapted from [https://github.com/kennethreitz/setup.py](https://github.com/kennethreitz/setup.py).
+
+[ref-arxiv-alice]: https://arxiv.org/abs/1808.00973
+[ref-arxiv-carl]: https://arxiv.org/abs/1506.02169
+[ref-arxiv-maf]: https://arxiv.org/abs/1705.07057
+[ref-arxiv-madminer-1]: https://arxiv.org/abs/1805.00013
+[ref-arxiv-madminer-2]: https://arxiv.org/abs/1805.00020
+[ref-arxiv-madminer-3]: https://arxiv.org/abs/1805.12244
+[ref-arxiv-scandal]: https://arxiv.org/abs/1705.07057
+[repo-madminer-contrib]: https://github.com/diana-hep/madminer/graphs/contributors
+[repo-maf-main-page]: https://github.com/gpapamak/maf

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,28 +1,31 @@
-# Trouble shooting
+# Trouble-shooting
 
 If you are having issues with MadMiner, please go through the following check list:
 
 
 ## Event generation crashing
 
-- Is MadGraph correctly installed? Can you generate events with MadGraph on its own, including the reweighting option?
-- If you are using Pythia and Delphes: Are their installations working? Can you run MadGraph with Pythia, and can you run Delphes on the resulting HepMC
-sample?
+- Is MadGraph correctly installed? Can you generate events with MadGraph on its own, including the reweighing option?
+- If you are using Pythia and Delphes: Are their installations working?
+  Can you run MadGraph with Pythia, and can you run Delphes on the resulting HepMC sample?
 - If you are using PDF or scale uncertainties: Is LHAPDF installed with Python support?
+
 
 ## Key errors when reading LHE files
 
 - Do LHE files contain multiple weights, one for each benchmark, for each event?
 
+
 ## Zero events after reading LHE or Delphes file
 
-- Are there typos in the definitions of required observables, cuts, or efficiencies? If an observable, cut, or
-efficiency causes all events to be discarded, DEBUG-level logging output should help you narrow down
-the source.
+- Are there typos in the definitions of required observables, cuts, or efficiencies?
+  If an observable, cut, or efficiency causes all events to be discarded, DEBUG-level logging output
+  should help you narrow down the source.
+
 
 ## Neural network output does not make sense
 
 - Start simple: one or two hidden layers are often enough for a start.
 - Does the loss go down during training? If not, try changing the learning rate.
-- Are the loss on the training and validation sample very different? This is the trademark sign of overtraining. Try
-a simpler network architecture, more data, or early stopping.
+- Are the loss on the training and validation sample very different? This is the trademark sign of over-training.
+  Try a simpler network architecture, more data, or early stopping.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,31 +5,27 @@ We provide different resources that help with the use of MadMiner:
 
 ## Paper
 
-Our main publication [MadMiner: Machine-learning-based inference for particle physics](https://arxiv.org/abs/1907.10621)
+Our main publication [MadMiner: Machine-learning-based inference for particle physics][ref-arxiv-link]
 provides an overview over this package. We recommend reading it first before jumping into the code.
 
 
 ## Tutorials
 
-In the [examples](https://github.com/diana-hep/madminer/tree/master/examples) folder in the MadMiner repository, we
-provide two tutorials. The first at
-[examples/tutorial_toy_simulator/tutorial_toy_simulator.ipynb](https://github.com/diana-hep/madminer/blob/master/examples/tutorial_toy_simulator/tutorial_toy_simulator.ipynb)
-is based on a toy problem rather than a full particle-physics simulation. It demonstrates
-inference with MadMiner without spending much time on the more technical steps of running the simulation. The second, at
-[examples/tutorial_particle_physics](https://github.com/diana-hep/madminer/tree/master/examples/tutorial_particle_physics),
-shows all steps of a particle-physics analysis with MadMiner.
+In the [examples][examples-folder-path] folder in this repository, we provide two tutorials. The first is called
+[_Toy simulator_][examples-simulator-path], and it is based on a toy problem rather than a full particle-physics simulation.
+It demonstrates inference with MadMiner without spending much time on the more technical steps of running the simulation.
+The second, called [_Particle physics_][examples-physics-path], shows all steps of a particle-physics analysis with MadMiner.
 
 
-## Typical work flow
+## Typical workflow
 
 Here we illustrate the structure of data analysis with MadMiner:
 
-![MadMiner workflow](img/workflow_combined.jpg)
+![MadMiner workflow][image-madminer-workflow]
 
-- `madminer.core` contains the functions to set up the process, parameter space, morphing, and to steer MadGraph and
-   Pythia.
+- `madminer.core` contains the functions to set up the process, parameter space, morphing, and to steer MadGraph and Pythia.
 - `madminer.lhe` and `madminer.delphes` contain two example implementations of a detector simulation and observable
-   calculation. This part can easily be swapped out depending on the use case.
+  calculation. This part can easily be swapped out depending on the use case.
 - In `madminer.sampling`, train and test samples for the machine learning part are generated and augmented with the
   joint score and joint ratio.
 - `madminer.ml`  contains an implementation of the machine learning part. The user can train and evaluate estimators
@@ -45,6 +41,12 @@ The madminer API is documented on here as well, just look through the pages link
 
 ## Support
 
-If you have any questions, please
-chat to us [in our Gitter community](https://gitter.im/madminer/community) or write us at 
-[johann.brehmer@nyu.edu](mailto:johann.brehmer@nyu.edu).
+If you have any questions, please chat to us in our [Gitter community][chat-gitter-link].
+
+
+[chat-gitter-link]: https://gitter.im/madminer/community
+[examples-folder-path]: https://github.com/diana-hep/madminer/tree/master/examples
+[examples-physics-path]: https://github.com/diana-hep/madminer/tree/master/examples/tutorial_particle_physics
+[examples-simulator-path]: https://github.com/diana-hep/madminer/blob/master/examples/tutorial_toy_simulator/tutorial_toy_simulator.ipynb
+[image-madminer-workflow]: img/workflow_combined.jpg
+[ref-arxiv-link]: https://arxiv.org/abs/1907.10621


### PR DESCRIPTION
This PR moves all documentation URLs to the bottom of each document by making use of Markdown's indirect references:

```markdown
In the documentation:
[text][identifier]

At the bottom:
[identifier]: url
```

This way of structuring documentation files provides the following benefits:
- Clarity when reading the docs on _raw mode_ (developers).
- Reusability of URLs throughout the same document.

### Additional changes
Finally, the [installation section](https://github.com/diana-hep/madminer/blob/ab9c8120622935b1491268e9196c1f5b75e3211d/docs/installation.md) of the docs has been simplified providing the shell scripts needed for installing both [Pythia8](https://pythia.org/) and [Delphes](https://cp3.irmp.ucl.ac.be/projects/delphes) using MadGraph 5 CLI.