### PR TITLE
Python 3 syntax improvements

### DIFF
--- a/madminer/analysis/dataanalyzer.py
+++ b/madminer/analysis/dataanalyzer.py
@@ -8,7 +8,7 @@ from madminer.utils.various import format_benchmark, mdot
 logger = logging.getLogger(__name__)
 
 
-class DataAnalyzer(object):
+class DataAnalyzer:
     """
     Collects common functionality that is used when analysing data in the MadMiner file.
 

--- a/madminer/delphes/delphes_reader.py
+++ b/madminer/delphes/delphes_reader.py
@@ -361,9 +361,7 @@ class DelphesReader:
             used: `e`, `mu`, `j`, `a`, and `l` provide lists of electrons, muons, jets, photons, and leptons (electrons
             and muons combined), in each case sorted by descending transverse momentum. `met` provides a missing ET
             object. `visible` and `all` provide access to the sum of all visible particles and the sum of all visible
-            particles plus MET, respectively. All these objects are instances of `MadMinerParticle`, which inherits from
-            scikit-hep's [LorentzVector](http://scikit-hep.org/api/math.html#vector-classes). See the link for a
-            documentation of their properties. In addition, `MadMinerParticle` have  properties `charge` and `pdg_id`,
+            particles plus MET, respectively. In addition, `MadMinerParticle` have  properties `charge` and `pdg_id`,
             which return the charge in units of elementary charges (i.e. an electron has `e[0].charge = -1.`), and the
             PDG particle ID. For instance, `"abs(j[0].phi() - j[1].phi())"` defines the azimuthal angle between the two
             hardest jets.
@@ -530,9 +528,7 @@ class DelphesReader:
             used: `e`, `mu`, `j`, `a`, and `l` provide lists of electrons, muons, jets, photons, and leptons (electrons
             and muons combined), in each case sorted by descending transverse momentum. `met` provides a missing ET
             object. `visible` and `all` provide access to the sum of all visible particles and the sum of all visible
-            particles plus MET, respectively. All these objects are instances of `MadMinerParticle`, which inherits from
-            scikit-hep's [LorentzVector](http://scikit-hep.org/api/math.html#vector-classes). See the link for a
-            documentation of their properties. In addition, `MadMinerParticle` have  properties `charge` and `pdg_id`,
+            particles plus MET, respectively. In addition, `MadMinerParticle` have  properties `charge` and `pdg_id`,
             which return the charge in units of elementary charges (i.e. an electron has `e[0].charge = -1.`), and the
             PDG particle ID. For instance, `"len(e) >= 2"` requires at least two electrons passing the acceptance cuts,
             while `"mu[0].charge > 0."` specifies that the hardest muon is positively charged.

--- a/madminer/lhe/lhe_reader.py
+++ b/madminer/lhe/lhe_reader.py
@@ -299,12 +299,10 @@ class LHEReader:
             used: `e`, `mu`, `tau`, `j`, `a`, `l`, `v` provide lists of electrons, muons, taus, jets, photons, leptons (
             electrons and muons combined), and neutrinos, in each case sorted by descending transverse momentum. `met` provides a
             missing ET object. `p` gives all particles in the same order as in the LHE file (i.e. in the same order as
-            defined in the MadGraph process card). All these objects are instances of `MadMinerParticle`, which
-            inherits from scikit-hep's [LorentzVector](http://scikit-hep.org/api/math.html#vector-classes). See the link
-            for a documentation of their properties. In addition, `MadMinerParticle` have  properties `charge` and
-            `pdg_id`, which return the charge in units of elementary charges (i.e. an electron has `e[0].charge = -1.`),
-            and the PDG particle ID. For instance, `"abs(j[0].phi() - j[1].phi())"` defines the azimuthal angle between
-            the two hardest jets.
+            defined in the MadGraph process card). In addition, `MadMinerParticle` have  properties `charge` and `pdg_id`,
+            which return the charge in units of elementary charges (i.e. an electron has `e[0].charge = -1.`), and the
+            PDG particle ID. For instance, `"abs(j[0].phi() - j[1].phi())"` defines the azimuthal angle between the two
+            hardest jets.
 
         required : bool, optional
             Whether the observable is required. If True, an event will only be retained if this observable is
@@ -467,9 +465,7 @@ class LHEReader:
             used: `e`, `mu`, `j`, `a`, and `l` provide lists of electrons, muons, jets, photons, and leptons (electrons
             and muons combined), in each case sorted by descending transverse momentum. `met` provides a missing ET
             object. `visible` and `all` provide access to the sum of all visible particles and the sum of all visible
-            particles plus MET, respectively. All these objects are instances of `MadMinerParticle`, which inherits from
-            scikit-hep's [LorentzVector](http://scikit-hep.org/api/math.html#vector-classes). See the link for a
-            documentation of their properties. In addition, `MadMinerParticle` have  properties `charge` and `pdg_id`,
+            particles plus MET, respectively. In addition, `MadMinerParticle` have  properties `charge` and `pdg_id`,
             which return the charge in units of elementary charges (i.e. an electron has `e[0].charge = -1.`), and the
             PDG particle ID. For instance, `"len(e) >= 2"` requires at least two electrons passing the cuts,
             while `"mu[0].charge > 0."` specifies that the hardest muon is positively charged.
@@ -495,19 +491,16 @@ class LHEReader:
         Parameters
         ----------
         definition : str
-        An expression that can be parsed by Python's `eval()` function and returns a floating number which reweights
-        the event weights. In the definition, all visible particles can be used: `e`, `mu`, `j`, `a`, and `l` provide
-        lists of electrons, muons, jets, photons, and leptons (electrons and muons combined), in each case sorted
-        by descending transverse momentum. `met` provides a missing ET object. `visible` and `all` provide access to
-        the sum of all visible particles and the sum of all visible particles plus MET, respectively. All these
-        objects are instances of `MadMinerParticle`, which inherits from scikit-hep's
-        [LorentzVector](http://scikit-hep.org/api/math.html#vector-classes). See the link for a
-        documentation of their properties. In addition, `MadMinerParticle` have  properties `charge` and `pdg_id`,
-        which return the charge in units of elementary charges (i.e. an electron has `e[0].charge = -1.`), and the
-        PDG particle ID.
+            An expression that can be parsed by Python's `eval()` function and returns a floating number which reweights
+            the event weights. In the definition, all visible particles can be used: `e`, `mu`, `j`, `a`, and `l` provide
+            lists of electrons, muons, jets, photons, and leptons (electrons and muons combined), in each case sorted
+            by descending transverse momentum. `met` provides a missing ET object. `visible` and `all` provide access to
+            the sum of all visible particles and the sum of all visible particles plus MET, respectively. In addition,
+            `MadMinerParticle` have  properties `charge` and `pdg_id`, which return the charge in units of elementary charges
+            (i.e. an electron has `e[0].charge = -1.`), and the PDG particle ID.
 
         value_if_not_parsed : float, optional
-        Value if te efficiency function cannot be parsed. Default value: 1.
+            Value if te efficiency function cannot be parsed. Default value: 1.
 
         Returns
         -------

--- a/madminer/likelihood/histo.py
+++ b/madminer/likelihood/histo.py
@@ -102,9 +102,9 @@ class HistoLikelihood(BaseLikelihood):
 
         # Check input and join observables and score components - nothing interesting
         if observables is None:
-            observables = list([])
+            observables = []
         if score_components is None:
-            score_components = list([])
+            score_components = []
         if observables == [] and score_components == []:
             logger.info("No observables and scores provided. Calculate LLR due to rate and set include_xsec=True.")
             include_xsec = True

--- a/madminer/likelihood/histo.py
+++ b/madminer/likelihood/histo.py
@@ -120,7 +120,7 @@ class HistoLikelihood(BaseLikelihood):
 
         # Load model - nothing interesting
         if score_components:
-            assert all([isinstance(score_component, int) for score_component in score_components])
+            assert all(isinstance(score_component, int) for score_component in score_components)
             if model_file is None:
                 raise ValueError("You need to provide a model_file!")
             model = load_estimator(model_file)
@@ -146,7 +146,7 @@ class HistoLikelihood(BaseLikelihood):
         # find binning
         logger.info("Setting up binning")
         if observables != [] and (
-            hist_bins is None or not all([hasattr(hist_bin, "__len__") for hist_bin in hist_bins])
+            hist_bins is None or not all(hasattr(hist_bin, "__len__") for hist_bin in hist_bins)
         ):
             if thetas_binning is None:
                 raise ValueError("Your input requires adaptive binning: thetas_binning can not be None.")

--- a/madminer/likelihood/histo.py
+++ b/madminer/likelihood/histo.py
@@ -428,7 +428,7 @@ class HistoLikelihood(BaseLikelihood):
 
         def summary_function(xs):
             # only prefined observables - very fast
-            if not "score" in x_indices and not "function" in x_indices:
+            if "score" not in x_indices and "function" not in x_indices:
                 return xs[:, x_indices]
 
             # evaluate some observables using eval() - more slow

--- a/madminer/limits/asymptotic_limits.py
+++ b/madminer/limits/asymptotic_limits.py
@@ -928,7 +928,7 @@ class AsymptoticLimits(DataAnalyzer):
         n_binning_toys=1000,
     ):
 
-        if fixed_adaptive_binning and (isinstance(x_bins, int) or any([isinstance(x, int) for x in x_bins])):
+        if fixed_adaptive_binning and (isinstance(x_bins, int) or any(isinstance(x, int) for x in x_bins)):
             if theta_binning is None:
                 logger.info("Determining fixed adaptive histogram binning for all points on grid")
                 x_bins = self._fixed_adaptive_binning(

--- a/madminer/ml/base.py
+++ b/madminer/ml/base.py
@@ -10,7 +10,7 @@ from ..utils.various import create_missing_folders, load_and_check
 logger = logging.getLogger(__name__)
 
 
-class Estimator(object):
+class Estimator:
     """
     Abstract class for any ML estimator. Subclassed by ParameterizedRatioEstimator, DoubleParameterizedRatioEstimator,
     ScoreEstimator, and LikelihoodEstimator.

--- a/madminer/ml/base.py
+++ b/madminer/ml/base.py
@@ -215,7 +215,7 @@ class Estimator:
         if self.features == "None":
             self.features = None
         if self.features is not None:
-            self.features = list([int(item) for item in self.features])
+            self.features = [int(item) for item in self.features]
 
         try:
             self.dropout_prob = float(settings["dropout_prob"])

--- a/madminer/utils/ml/trainer.py
+++ b/madminer/utils/ml/trainer.py
@@ -18,7 +18,7 @@ from madminer.utils.ml.utils import (
 logger = logging.getLogger(__name__)
 
 
-class Trainer(object):
+class Trainer:
     """ Trainer class. Any subclass has to implement the forward_pass() function. """
 
     def __init__(self, model, run_on_gpu=True, double_precision=False, n_workers=8):

--- a/madminer/utils/ml/utils.py
+++ b/madminer/utils/ml/utils.py
@@ -184,7 +184,7 @@ def get_loss(method, alpha):
         loss_weights = [1.0, alpha]
         loss_labels = ["nll", "mse_score"]
     else:
-        raise NotImplementedError("Unknown method {method}")
+        raise NotImplementedError(f"Unknown method {method}")
 
     return loss_functions, loss_labels, loss_weights
 


### PR DESCRIPTION
This PR updates the current codebase by removing unnecessary constructors and inheritances carried over from the _Python 2 compatibility_ era. In addition, references to the [scikit-hep](https://pypi.org/project/scikit-hep/) package have been removed, as the project [no longer uses it](https://github.com/diana-hep/madminer/pull/458).

The rest of the changes are self explanatory.