### PR TITLE
Return arrays with training and validation losses in Ensemble methods + updating documentation

### DIFF
--- a/madminer/ml/double_parameterized_ratio.py
+++ b/madminer/ml/double_parameterized_ratio.py
@@ -186,8 +186,8 @@ class DoubleParameterizedRatioEstimator(ConditionalEstimator):
 
         Returns
         -------
-            None
-
+        result: ndarray
+            Training and validation losses from DoubleParameterizedRatioTrainer.train
         """
 
         logger.info("Starting training")

--- a/madminer/ml/ensemble.py
+++ b/madminer/ml/ensemble.py
@@ -108,10 +108,13 @@ class Ensemble:
 
         Returns
         -------
-            None
+        result: ndarray
+            Training and validation losses from estimator training
+            
         """
 
-        self.estimators[i].train(**kwargs)
+        result=self.estimators[i].train(**kwargs)
+        return result
 
     def train_all(self, **kwargs):
         """
@@ -126,9 +129,13 @@ class Ensemble:
 
         Returns
         -------
-            None
+        result_list: list of ndarray
+            List of training and validation losses from estimator training
+
         """
         logger.info("Training %s estimators in ensemble", self.n_estimators)
+
+        result_list=[]
 
         for key, value in kwargs.items():
             if not isinstance(value, list):
@@ -142,7 +149,10 @@ class Ensemble:
                 kwargs_this_estimator[key] = value[i]
 
             logger.info("Training estimator %s / %s in ensemble", i + 1, self.n_estimators)
-            estimator.train(**kwargs_this_estimator)
+            result=estimator.train(**kwargs_this_estimator)
+            result_list.append(result)
+
+        return result_list
 
     def evaluate_log_likelihood(self, estimator_weights=None, calculate_covariance=False, **kwargs):
         """

--- a/madminer/ml/likelihood.py
+++ b/madminer/ml/likelihood.py
@@ -168,8 +168,8 @@ class LikelihoodEstimator(ConditionalEstimator):
 
         Returns
         -------
-            None
-
+        result: ndarray
+            Training and validation losses from FlowTrainer.train
         """
 
         logger.info("Starting training")

--- a/madminer/ml/parameterized_ratio.py
+++ b/madminer/ml/parameterized_ratio.py
@@ -172,8 +172,8 @@ class ParameterizedRatioEstimator(ConditionalEstimator):
 
         Returns
         -------
-        results: ndarray
-            Results from SingleParameterizedRatioTrainer.train or DoubleParameterizedRatioTrainer.train for example
+        result: ndarray
+            Training and validation losses from SingleParameterizedRatioTrainer.train or DoubleParameterizedRatioTrainer.train for example
 
         """
 

--- a/madminer/ml/score.py
+++ b/madminer/ml/score.py
@@ -126,8 +126,8 @@ class ScoreEstimator(Estimator):
 
         Returns
         -------
-            None
-
+        result: ndarray
+            Training and validation losses from LocalScoreTrainer.train
         """
 
         if method not in ["sally", "sallino"]:


### PR DESCRIPTION
Standard MadMiner _train_ methods return a tuple with the Numpy arrays with training and validation loss, but this was not implemented for the Ensemble methods. With these code changes, the Ensemble _train_one_ method returns a similar tuple, and the _train_all_ method returns a list with N tuples, where N is the number of estimators in the Ensemble.

Also, I updated the documentation to mention explicitly that the train methods return the training and validation losses.

Any feedback is much appreciated.