### PR TITLE
Define custom dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+
+updates:
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    ignore:
+      # Ignore auto-updates on SemVer major releases
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    ignore:
+      # Ignore auto-updates on SemVer major releases
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    allow:
+      - dependency-type: development
+      - dependency-type: production


### PR DESCRIPTION
This PR activates 🤖  GitHub dependabot automatic updates on both GitHub Actions and Python dependencies. The updates are triggered **weekly on Mondays** (default day).

### 📋 Considerations
- [SemVer](https://semver.org/) `major` version updates are ignored for now, as a security measure.

### 📚  References
- [GitHub dependabot documentation](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates).