### PR TITLE
Fix MadMiner particle initialization

### DIFF
--- a/madminer/utils/interfaces/delphes_root.py
+++ b/madminer/utils/interfaces/delphes_root.py
@@ -91,7 +91,7 @@ def parse_delphes_root_file(
 
     # Prepare variables
     def get_objects(ievent):
-        visible_momentum = MadMinerParticle()
+        visible_momentum = MadMinerParticle.from_xyzt(0.0, 0.0, 0.0, 0.0)
         for p in (
             electrons_all_events[ievent]
             + jets_all_events[ievent]
@@ -268,8 +268,7 @@ def _get_particles_truth(tree, pt_min, eta_max, included_pdgids=None):
             if (included_pdgids is not None) and (not pdgid in included_pdgids):
                 continue
 
-            particle = MadMinerParticle()
-            particle.from_rhophietat(pt, phi, eta, e)
+            particle = MadMinerParticle.from_rhophietat(pt, phi, eta, e)
             particle.set_pdgid(pdgid)
             event_particles.append(particle)
 
@@ -298,8 +297,7 @@ def _get_particles_charged(tree, name, mass, pdgid_positive_charge, pt_min, eta_
 
             pdgid = pdgid_positive_charge if charge >= 0.0 else -pdgid_positive_charge
 
-            particle = MadMinerParticle()
-            particle.from_rhophietatau(pt, phi, eta, mass)
+            particle = MadMinerParticle.from_rhophietatau(pt, phi, eta, mass)
             particle.set_pdgid(pdgid)
             event_particles.append(particle)
 
@@ -362,8 +360,7 @@ def _get_particles_leptons(tree, pt_min_e, eta_max_e, pt_min_mu, eta_max_mu):
                 logger.warning("Delphes ROOT file has lepton with PDG ID %s, ignoring it", pdgid)
                 continue
 
-            particle = MadMinerParticle()
-            particle.from_rhophietatau(pt, phi, eta, mass)
+            particle = MadMinerParticle.from_rhophietatau(pt, phi, eta, mass)
             particle.set_pdgid(pdgid)
             event_particles.append(particle)
 
@@ -397,8 +394,7 @@ def _get_particles_truth_leptons(tree, pt_min_e, eta_max_e, pt_min_mu, eta_max_m
             if pdgid in [13, -13] and (eta_max_mu is not None and abs(eta) > eta_max_mu):
                 continue
 
-            particle = MadMinerParticle()
-            particle.from_rhophietat(pt, phi, eta, e)
+            particle = MadMinerParticle.from_rhophietat(pt, phi, eta, e)
             particle.set_pdgid(pdgid)
             event_particles.append(particle)
 
@@ -425,8 +421,7 @@ def _get_particles_photons(tree, pt_min, eta_max):
             if eta_max is not None and abs(eta) > eta_max:
                 continue
 
-            particle = MadMinerParticle()
-            particle.from_rhophietat(pt, phi, eta, e)
+            particle = MadMinerParticle.from_rhophietat(pt, phi, eta, e)
             particle.set_pdgid(22)
             event_particles.append(particle)
 
@@ -465,8 +460,7 @@ def _get_particles_jets(tree, pt_min, eta_max):
             if eta_max is not None and abs(eta) > eta_max:
                 continue
 
-            particle = MadMinerParticle()
-            particle.from_rhophietatau(pt, phi, eta, mass)
+            particle = MadMinerParticle.from_rhophietatau(pt, phi, eta, mass)
             particle.set_pdgid(9)
             particle.set_tags(tau_tag >= 1, b_tag >= 1, False)
             event_particles.append(particle)
@@ -506,8 +500,7 @@ def _get_particles_truth_jets(tree, pt_min, eta_max):
             if eta_max is not None and abs(eta) > eta_max:
                 continue
 
-            particle = MadMinerParticle()
-            particle.from_rhophietatau(pt, phi, eta, mass)
+            particle = MadMinerParticle.from_rhophietatau(pt, phi, eta, mass)
             particle.set_pdgid(9)
             particle.set_tags(tau_tag >= 1, b_tag >= 1, False)
             event_particles.append(particle)
@@ -527,8 +520,7 @@ def _get_particles_truth_met(tree):
         event_particles = []
 
         for met, phi in zip(mets[ievent], phis[ievent]):
-            particle = MadMinerParticle()
-            particle.from_rhophietatau(met, phi, 0.0, 0.0)
+            particle = MadMinerParticle.from_rhophietatau(met, phi, 0.0, 0.0)
             particle.set_pdgid(0)
             event_particles.append(particle)
 
@@ -547,8 +539,7 @@ def _get_particles_met(tree):
         event_particles = []
 
         for met, phi in zip(mets[ievent], phis[ievent]):
-            particle = MadMinerParticle()
-            particle.from_rhophietatau(met, phi, 0.0, 0.0)
+            particle = MadMinerParticle.from_rhophietatau(met, phi, 0.0, 0.0)
             particle.set_pdgid(0)
             event_particles.append(particle)
 

--- a/madminer/utils/interfaces/lhe.py
+++ b/madminer/utils/interfaces/lhe.py
@@ -743,8 +743,7 @@ def _parse_xml_event(event, sampling_benchmark):
             pz = float(elements[8])
             e = float(elements[9])
             spin = float(elements[12])
-            particle = MadMinerParticle()
-            particle.from_xyzt(px, py, pz, e)
+            particle = MadMinerParticle.from_xyzt(px, py, pz, e)
             particle.set_pdgid(pdgid)
             particle.set_spin(spin)
             particles.append(particle)
@@ -853,8 +852,7 @@ def _parse_txt_events(filename, sampling_benchmark):
                     pz = float(elements[8])
                     e = float(elements[9])
                     spin = float(elements[12])
-                    particle = MadMinerParticle()
-                    particle.from_xyzt(px, py, pz, e)
+                    particle = MadMinerParticle.from_xyzt(px, py, pz, e)
                     particle.set_pdgid(pdgid)
                     particle.set_spin(spin)
                     particles.append(particle)
@@ -944,8 +942,7 @@ def _get_objects(particles, particles_truth, met_resolution=None, global_event_d
 
     # Sum over all particles
     ht = 0.0
-    visible_sum = MadMinerParticle()
-    visible_sum.from_xyzt(0.0, 0.0, 0.0, 0.0)
+    visible_sum = MadMinerParticle.from_xyzt(0.0, 0.0, 0.0, 0.0)
 
     for particle in particles:
         pdgid = abs(particle.pdgid)
@@ -965,8 +962,12 @@ def _get_objects(particles, particles_truth, met_resolution=None, global_event_d
     # MET
     met_x = -visible_sum.x + noise_x
     met_y = -visible_sum.y + noise_y
-    met = MadMinerParticle()
-    met.from_xyzt(met_x, met_y, 0.0, (met_x ** 2 + met_y ** 2) ** 0.5)
+    met = MadMinerParticle.from_xyzt(
+        x=met_x,
+        y=met_y,
+        z=0.0,
+        t=(met_x ** 2 + met_y ** 2) ** 0.5,
+    )
 
     # Build objects
     objects = math_commands()
@@ -1054,12 +1055,9 @@ def _smear_particles(particles, energy_resolutions, pt_resolutions, eta_resoluti
         while phi < 0.0:
             phi += 2.0 * np.pi
 
-        # Construct particle
-        smeared_particle = MadMinerParticle()
-
         if None in energy_resolutions[pdgid]:
             # Calculate E from on-shell conditions
-            smeared_particle.from_rhophietatau(pt, phi, eta, particle.m)
+            smeared_particle = MadMinerParticle.from_rhophietatau(pt, phi, eta, particle.m)
 
         elif None in pt_resolutions[pdgid]:
             # Calculate pT from on-shell conditions
@@ -1067,15 +1065,14 @@ def _smear_particles(particles, energy_resolutions, pt_resolutions, eta_resoluti
                 pt = (e ** 2 - m ** 2) ** 0.5 / np.cosh(eta)
             else:
                 pt = 0.0
-            smeared_particle.from_rhophietat(pt, phi, eta, e)
+            smeared_particle = MadMinerParticle.from_rhophietat(pt, phi, eta, e)
 
         else:
             # Everything smeared manually
-            smeared_particle.from_rhophietat(pt, phi, eta, e)
+            smeared_particle = MadMinerParticle.from_rhophietat(pt, phi, eta, e)
 
         # PDG id (also sets charge)
         smeared_particle.set_pdgid(pdgid)
-
         smeared_particles.append(smeared_particle)
 
     return smeared_particles

--- a/madminer/utils/particle.py
+++ b/madminer/utils/particle.py
@@ -99,7 +99,7 @@ class MadMinerParticle(vector.VectorObject4D):
     def boost(self, *args):
         vec = super(MadMinerParticle, self).boost(*args)
 
-        particle = MadMinerParticle().from_xyzt(vec.x, vec.y, vec.z, vec.t)
+        particle = MadMinerParticle.from_xyzt(vec.x, vec.y, vec.z, vec.t)
         particle.charge = self.charge
         particle.spin = self.spin
         particle.pdgid = self.pdgid


### PR DESCRIPTION
This PR addresses issue https://github.com/diana-hep/madminer/issues/470, which describes an exception being raised when the `MadMinerParticle` class is being initialized within several interface modules ([delphes_root.py](https://github.com/diana-hep/madminer/blob/master/madminer/utils/interfaces/delphes_root.py), [lhe.py](https://github.com/diana-hep/madminer/blob/master/madminer/utils/interfaces/lhe.py)...).

The bug was initially introduced on the `scikit-hep` -> `vector` [migration PR](https://github.com/diana-hep/madminer/pull/458), as the _scikit-hep_ based class from which `MadMinerParticle` inherited from (`LorentzVector`) defined default argument values, but the _vector_ based one (`VectorObject4D`) does not.

When using the latter, we must replaced the usual initialization by one of the class-method helpers.