### PR TITLE
Replace Madminer particle inherited class

### DIFF
--- a/madminer/utils/particle.py
+++ b/madminer/utils/particle.py
@@ -4,7 +4,7 @@ import vector
 logger = logging.getLogger(__name__)
 
 
-class MadMinerParticle(vector.VectorObject4D):
+class MadMinerParticle(vector.MomentumObject4D):
     """ """
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This PR addresses issue https://github.com/diana-hep/madminer/issues/470, which describes an exception being raised when the `MadMinerParticle` properties `m` (mass) and `e` (energy) are being accessed.

The bug was initially introduced on the `scikit-hep` -> `vector` [migration PR](https://github.com/diana-hep/madminer/pull/458), as the chosen class to inherit from, [ObjectVector4D](https://github.com/scikit-hep/vector/blob/v0.8.3/src/vector/_backends/object_.py#L921), does not expose does properties. The parent class must be substituted by [MomentumVector4D](https://github.com/scikit-hep/vector/blob/v0.8.3/src/vector/_backends/object_.py#L1353) instead.