### PR TITLE
Migrate super() calls to Python3

### DIFF
--- a/madminer/analysis/dataanalyzer.py
+++ b/madminer/analysis/dataanalyzer.py
@@ -363,7 +363,8 @@ class DataAnalyzer:
 
         if n_events == 0:
             raise RuntimeError(
-                "Did not find events with test_split = %s and generated_close_to = %s", test_split, generated_close_to
+                f"Did not find events with test_split = {test_split} "
+                f"and generated_close_to = {generated_close_to}"
             )
 
         xsec_uncertainties = np.maximum(xsec_uncertainties, 0.0) ** 0.5

--- a/madminer/fisherinformation/geometry.py
+++ b/madminer/fisherinformation/geometry.py
@@ -90,7 +90,7 @@ class InformationGeometry:
         elif option == "smooth":
             self.infofunction = CloughTocher2DInterpolator(points=theta_grid, values=np.array(fisherinformation_grid))
         else:
-            RuntimeError("Option %s unknown", option)
+            RuntimeError(f"Option unknown: {option}")
 
         # Interpolate inverse information
         if self.inverse == "interpolate":

--- a/madminer/fisherinformation/information.py
+++ b/madminer/fisherinformation/information.py
@@ -249,12 +249,10 @@ class FisherInformation(DataAnalyzer):
             include_nuisance_parameters = True
         else:
             raise RuntimeError(
-                "Inconsistent numbers of parameters! Found %s in %s model, %s physical parameters in "
-                "MadMiner file, and %s nuisance parameters in MadMiner file.",
-                model.n_parameters,
-                model_type,
-                self.n_parameters,
-                self.n_nuisance_parameters,
+                f"Inconsistent numbers of parameters! "
+                f"Found {model.n_parameters} in {model_type} model, "
+                f"but {self.n_parameters} physical parameters, "
+                f"and {self.n_nuisance_parameters} nuisance parameters in MadMiner file."
             )
 
         if include_nuisance_parameters:
@@ -886,11 +884,10 @@ class FisherInformation(DataAnalyzer):
                 include_nuisance_parameters = True
             else:
                 raise RuntimeError(
-                    "Inconsistent numbers of parameters! Found %s in SALLY model, %s physical parameters in "
-                    "MadMiner file, and %s nuisance parameters in MadMiner file.",
-                    model.n_parameters,
-                    self.n_parameters,
-                    self.n_nuisance_parameters,
+                    f"Inconsistent numbers of parameters! "
+                    f"Found {model.n_parameters} in SALLY model, "
+                    f"but {self.n_parameters} physical parameters in MadMiner file, "
+                    f"and {self.n_nuisance_parameters} nuisance parameters in MadMiner file."
                 )
 
             # Total xsec

--- a/madminer/fisherinformation/information.py
+++ b/madminer/fisherinformation/information.py
@@ -46,7 +46,7 @@ class FisherInformation(DataAnalyzer):
     """
 
     def __init__(self, filename, include_nuisance_parameters=True):
-        super(FisherInformation, self).__init__(filename, False, include_nuisance_parameters)
+        super().__init__(filename, False, include_nuisance_parameters)
 
     def truth_information(
         self,

--- a/madminer/lhe/lhe_reader.py
+++ b/madminer/lhe/lhe_reader.py
@@ -122,7 +122,8 @@ class LHEReader:
 
             if this_n_events != n_events:
                 raise RuntimeError(
-                    f"Mismatching number of events for {key}: "f"{n_events} vs {this_n_events}")
+                    f"Mismatching number of events for {key}: "f"{n_events} vs {this_n_events}"
+                )
 
             if not np.issubdtype(elems.dtype, np.number):
                 logger.warning(f"For key {key} have non-numeric dtype {elems.dtype}.")

--- a/madminer/limits/asymptotic_limits.py
+++ b/madminer/limits/asymptotic_limits.py
@@ -48,7 +48,7 @@ class AsymptoticLimits(DataAnalyzer):
         if include_nuisance_parameters:
             raise NotImplementedError("AsymptoticLimits does not yet support nuisance parameters.")
 
-        super(AsymptoticLimits, self).__init__(filename, False, include_nuisance_parameters=False)
+        super().__init__(filename, False, include_nuisance_parameters=False)
 
     def observed_limits(
         self,

--- a/madminer/ml/base.py
+++ b/madminer/ml/base.py
@@ -302,7 +302,7 @@ class ConditionalEstimator(Estimator):
     """
 
     def __init__(self, features=None, n_hidden=(100,), activation="tanh", dropout_prob=0.0):
-        super(ConditionalEstimator, self).__init__(features, n_hidden, activation, dropout_prob)
+        super().__init__(features, n_hidden, activation, dropout_prob)
 
         self.theta_scaling_means = None
         self.theta_scaling_stds = None
@@ -328,7 +328,7 @@ class ConditionalEstimator(Estimator):
 
         """
 
-        super(ConditionalEstimator, self).save(filename, save_model)
+        super().save(filename, save_model)
 
         # Save param scaling
         if self.theta_scaling_stds is not None and self.theta_scaling_means is not None:
@@ -354,7 +354,7 @@ class ConditionalEstimator(Estimator):
 
         """
 
-        super(ConditionalEstimator, self).load(filename)
+        super().load(filename)
 
         # Load param scaling
         try:

--- a/madminer/ml/double_parameterized_ratio.py
+++ b/madminer/ml/double_parameterized_ratio.py
@@ -15,23 +15,8 @@ logger = logging.getLogger(__name__)
 
 class DoubleParameterizedRatioEstimator(ConditionalEstimator):
     """
-    A neural estimator of the likelihood ratio as a function of the observation x, the numerator hypothesis theta0, and
-    the denominator hypothesis theta1.
-
-    Parameters
-    ----------
-    features : list of int or None, optional
-        Indices of observables (features) that are used as input to the neural networks. If None, all observables
-        are used. Default value: None.
-
-    n_hidden : tuple of int, optional
-        Units in each hidden layer in the neural networks. If method is 'nde' or 'scandal', this refers to the
-        setup of each individual MADE layer. Default value: (100,).
-
-    activation : {'tanh', 'sigmoid', 'relu'}, optional
-        Activation function. Default value: 'tanh'.
-
-
+    A neural estimator of the likelihood ratio as a function of the observation x,
+    the numerator hypothesis theta0, and the denominator hypothesis theta1.
     """
 
     def train(

--- a/madminer/ml/double_parameterized_ratio.py
+++ b/madminer/ml/double_parameterized_ratio.py
@@ -517,12 +517,12 @@ class DoubleParameterizedRatioEstimator(ConditionalEstimator):
         return data
 
     def _wrap_settings(self):
-        settings = super(DoubleParameterizedRatioEstimator, self)._wrap_settings()
+        settings = super()._wrap_settings()
         settings["estimator_type"] = "double_parameterized_ratio"
         return settings
 
     def _unwrap_settings(self, settings):
-        super(DoubleParameterizedRatioEstimator, self)._unwrap_settings(settings)
+        super()._unwrap_settings(settings)
 
         estimator_type = str(settings["estimator_type"])
         if estimator_type != "double_parameterized_ratio":

--- a/madminer/ml/likelihood.py
+++ b/madminer/ml/likelihood.py
@@ -47,7 +47,7 @@ class LikelihoodEstimator(ConditionalEstimator):
     """
 
     def __init__(self, features=None, n_components=1, n_mades=5, n_hidden=(100,), activation="tanh", batch_norm=None):
-        super(LikelihoodEstimator, self).__init__(features, n_hidden, activation, dropout_prob=0.0)
+        super().__init__(features, n_hidden, activation, dropout_prob=0.0)
 
         self.n_components = n_components
         self.n_mades = n_mades
@@ -517,7 +517,7 @@ class LikelihoodEstimator(ConditionalEstimator):
         return data
 
     def _wrap_settings(self):
-        settings = super(LikelihoodEstimator, self)._wrap_settings()
+        settings = super()._wrap_settings()
         settings["estimator_type"] = "likelihood"
         settings["n_components"] = self.n_components
         settings["batch_norm"] = self.batch_norm
@@ -525,7 +525,7 @@ class LikelihoodEstimator(ConditionalEstimator):
         return settings
 
     def _unwrap_settings(self, settings):
-        super(LikelihoodEstimator, self)._unwrap_settings(settings)
+        super()._unwrap_settings(settings)
 
         estimator_type = str(settings["estimator_type"])
         if estimator_type != "likelihood":

--- a/madminer/ml/morphing_aware.py
+++ b/madminer/ml/morphing_aware.py
@@ -101,7 +101,7 @@ class QuadraticMorphingAwareRatioEstimator(ParameterizedRatioEstimator):
     """
 
     def train(self, *args, **kwargs):
-        super().train(*args, scale_parameters=False, **kwargs)
+        super().train(*args, **kwargs, scale_parameters=False)
 
     def _create_model(self):
         self.model = DenseQuadraticMorphingAwareRatioModel(

--- a/madminer/ml/morphing_aware.py
+++ b/madminer/ml/morphing_aware.py
@@ -37,7 +37,7 @@ class MorphingAwareRatioEstimator(ParameterizedRatioEstimator):
                 "estimator!"
             )
 
-        super(MorphingAwareRatioEstimator, self).train(*args, scale_parameters=False, **kwargs)
+        super().train(*args, scale_parameters=False, **kwargs)
 
     def _load_morphing_setup(self, filename, optimize_morphing_basis=False):
         (
@@ -81,13 +81,13 @@ class MorphingAwareRatioEstimator(ParameterizedRatioEstimator):
         )
 
     def _wrap_settings(self):
-        settings = super(MorphingAwareRatioEstimator, self)._wrap_settings()
+        settings = super()._wrap_settings()
         settings["components"] = self.components.tolist()
         settings["morphing_matrix"] = self.morphing_matrix.tolist()
         return settings
 
     def _unwrap_settings(self, settings):
-        super(MorphingAwareRatioEstimator, self)._unwrap_settings(settings)
+        super()._unwrap_settings(settings)
 
         self.components = np.array(settings["components"])
         self.morphing_matrix = np.array(settings["morphing_matrix"])
@@ -101,7 +101,7 @@ class QuadraticMorphingAwareRatioEstimator(ParameterizedRatioEstimator):
     """
 
     def train(self, *args, **kwargs):
-        super(QuadraticMorphingAwareRatioEstimator, self).train(*args, scale_parameters=False, **kwargs)
+        super().train(*args, scale_parameters=False, **kwargs)
 
     def _create_model(self):
         self.model = DenseQuadraticMorphingAwareRatioModel(

--- a/madminer/ml/morphing_aware.py
+++ b/madminer/ml/morphing_aware.py
@@ -20,7 +20,7 @@ class MorphingAwareRatioEstimator(ParameterizedRatioEstimator):
         activation="tanh",
         dropout_prob=0.0,
     ):
-        super(ParameterizedRatioEstimator, self).__init__(features, n_hidden, activation, dropout_prob)
+        super().__init__(features, n_hidden, activation, dropout_prob)
 
         if morphing_setup_filename is not None:
             self.components, self.morphing_matrix = self._load_morphing_setup(

--- a/madminer/ml/parameterized_ratio.py
+++ b/madminer/ml/parameterized_ratio.py
@@ -498,9 +498,6 @@ class ParameterizedRatioEstimator(ConditionalEstimator):
         _, all_t_hat = self.evaluate_log_likelihood_ratio(x, theta, test_all_combinations=False, evaluate_score=True)
         return all_t_hat
 
-    def calculate_fisher_information(self, x, theta, weights=None, n_events=1, sum_events=True):
-        return super().calculate_fisher_information(x, theta, weights, n_events, sum_events)
-
     def evaluate(self, *args, **kwargs):
         return self.evaluate_log_likelihood_ratio(*args, **kwargs)
 

--- a/madminer/ml/parameterized_ratio.py
+++ b/madminer/ml/parameterized_ratio.py
@@ -19,21 +19,6 @@ class ParameterizedRatioEstimator(ConditionalEstimator):
     A neural estimator of the likelihood ratio as a function of the observation x as well as
     the numerator hypothesis theta. The reference (denominator) hypothesis is kept fixed at some
     reference value and NOT modeled by the network.
-
-    Parameters
-    ----------
-    features : list of int or None, optional
-        Indices of observables (features) that are used as input to the neural networks. If None, all observables
-        are used. Default value: None.
-
-    n_hidden : tuple of int, optional
-        Units in each hidden layer in the neural networks. If method is 'nde' or 'scandal', this refers to the
-        setup of each individual MADE layer. Default value: (100,).
-
-    activation : {'tanh', 'sigmoid', 'relu'}, optional
-        Activation function. Default value: 'tanh'.
-
-
     """
 
     def train(

--- a/madminer/ml/parameterized_ratio.py
+++ b/madminer/ml/parameterized_ratio.py
@@ -499,8 +499,7 @@ class ParameterizedRatioEstimator(ConditionalEstimator):
         return all_t_hat
 
     def calculate_fisher_information(self, x, theta, weights=None, n_events=1, sum_events=True):
-        return super(ParameterizedRatioEstimator, self) \
-            .calculate_fisher_information(x, theta, weights, n_events, sum_events)
+        return super().calculate_fisher_information(x, theta, weights, n_events, sum_events)
 
     def evaluate(self, *args, **kwargs):
         return self.evaluate_log_likelihood_ratio(*args, **kwargs)
@@ -534,12 +533,12 @@ class ParameterizedRatioEstimator(ConditionalEstimator):
         return data
 
     def _wrap_settings(self):
-        settings = super(ParameterizedRatioEstimator, self)._wrap_settings()
+        settings = super()._wrap_settings()
         settings["estimator_type"] = "parameterized_ratio"
         return settings
 
     def _unwrap_settings(self, settings):
-        super(ParameterizedRatioEstimator, self)._unwrap_settings(settings)
+        super()._unwrap_settings(settings)
 
         estimator_type = str(settings["estimator_type"])
         if estimator_type != "parameterized_ratio":

--- a/madminer/ml/score.py
+++ b/madminer/ml/score.py
@@ -33,7 +33,7 @@ class ScoreEstimator(Estimator):
     """
 
     def __init__(self, features=None, n_hidden=(100,), activation="tanh", dropout_prob=0.0):
-        super(ScoreEstimator, self).__init__(features, n_hidden, activation, dropout_prob)
+        super().__init__(features, n_hidden, activation, dropout_prob)
 
         self.nuisance_profile_matrix = None
         self.nuisance_project_matrix = None
@@ -388,11 +388,10 @@ class ScoreEstimator(Estimator):
         return self.evaluate_score(*args, **kwargs)
 
     def calculate_fisher_information(self, x, theta=None, weights=None, n_events=1, sum_events=True):
-        return super(ScoreEstimator, self) \
-            .calculate_fisher_information(x, theta, weights, n_events, sum_events)
+        return super().calculate_fisher_information(x, theta, weights, n_events, sum_events)
 
     def save(self, filename, save_model=False):
-        super(ScoreEstimator, self).save(filename, save_model)
+        super().save(filename, save_model)
 
         # Also save Fisher information information for profiling / projections
         if self.nuisance_profile_matrix is not None and self.nuisance_project_matrix is not None:
@@ -406,7 +405,7 @@ class ScoreEstimator(Estimator):
             np.save(f"{filename}_nuisance_project_matrix.npy", self.nuisance_project_matrix)
 
     def load(self, filename):
-        super(ScoreEstimator, self).load(filename)
+        super().load(filename)
 
         # Load scaling
         try:
@@ -439,13 +438,13 @@ class ScoreEstimator(Estimator):
         return data
 
     def _wrap_settings(self):
-        settings = super(ScoreEstimator, self)._wrap_settings()
+        settings = super()._wrap_settings()
         settings["estimator_type"] = "score"
         settings["nuisance_mode_default"] = self.nuisance_mode_default
         return settings
 
     def _unwrap_settings(self, settings):
-        super(ScoreEstimator, self)._unwrap_settings(settings)
+        super()._unwrap_settings(settings)
 
         estimator_type = str(settings["estimator_type"])
         if estimator_type != "score":

--- a/madminer/ml/score.py
+++ b/madminer/ml/score.py
@@ -387,9 +387,6 @@ class ScoreEstimator(Estimator):
     def evaluate(self, *args, **kwargs):
         return self.evaluate_score(*args, **kwargs)
 
-    def calculate_fisher_information(self, x, theta=None, weights=None, n_events=1, sum_events=True):
-        return super().calculate_fisher_information(x, theta, weights, n_events, sum_events)
-
     def save(self, filename, save_model=False):
         super().save(filename, save_model)
 

--- a/madminer/plotting/fisherinformation.py
+++ b/madminer/plotting/fisherinformation.py
@@ -326,9 +326,7 @@ def plot_fisherinfo_barplot(
 
             fraction_finished = 0.0
 
-            for component in range(len(composition)):
-                fraction = composition[component]
-
+            for component, fraction in enumerate(composition):
                 if fraction >= minimal_fraction_for_plot:
                     plt.hlines(
                         [eigenvalue],

--- a/madminer/plotting/limits.py
+++ b/madminer/plotting/limits.py
@@ -56,13 +56,13 @@ def plot_pvalue_limits(
         list of p-values used to draw contour lines. Default: [0.32]
 
     single_plot : bool, optional
-        If True, only one sumamry plot is shown which contains confidence contours and
+        If True, only one summary plot is shown which contains confidence contours and
         best fit points for all methods, and the p-value grid for a selected method
         (if show_index is not None). If False, additional plots with the p-value grid,
         confidence contours and best fit points for all methods are provided. Default: True
 
     show_index : int, optional
-        If None, no p-value grid is shown in sumamry plot. If show_index=n, the p-value
+        If None, no p-value grid is shown in summary plot. If show_index=n, the p-value
         grid of the nth method is shown in the summary plot. Default is None.
 
     xlabel,ylabel : string, optional
@@ -133,21 +133,21 @@ def plot_pvalue_limits(
         )
         cbar = fig.colorbar(pcm, ax=ax, extend="both")
         cbar.set_label(f"Expected p-value ({labels[show_index]})")
-    for ipanel in range(len(p_values)):
+    for i, panel in enumerate(p_values):
         ax.contour(
             xcenters,
             ycenters,
-            p_values[ipanel].reshape((grid_resolutions[0], grid_resolutions[1])).T,
+            panel.reshape((grid_resolutions[0], grid_resolutions[1])).T,
             levels=levels,
-            colors=f"C{ipanel}",
+            colors=f"C{i}",
         )
         ax.scatter(
-            theta_grid[best_fits[ipanel]][0],
-            theta_grid[best_fits[ipanel]][1],
+            theta_grid[best_fits[i]][0],
+            theta_grid[best_fits[i]][1],
             s=80.0,
-            color=f"C{ipanel}",
+            color=f"C{i}",
             marker="*",
-            label=labels[ipanel],
+            label=labels[i],
         )
     ax.set_xlabel(xlabel)
     ax.set_ylabel(ylabel)
@@ -155,31 +155,31 @@ def plot_pvalue_limits(
 
     # individual summary plot
     if single_plot is not True:
-        for ipanel in range(len(p_values)):
-            ax = plt.subplot(n_rows, n_cols, ipanel + 2)
+        for i, panel in enumerate(p_values):
+            ax = plt.subplot(n_rows, n_cols, i + 2)
             pcm = ax.pcolormesh(
                 xedges,
                 yedges,
-                p_values[ipanel].reshape((grid_resolutions[0], grid_resolutions[1])).T,
+                panel.reshape((grid_resolutions[0], grid_resolutions[1])).T,
                 norm=matplotlib.colors.LogNorm(vmin=p_val_min, vmax=p_val_max),
                 cmap="Greys_r",
             )
             cbar = fig.colorbar(pcm, ax=ax, extend="both")
-            cbar.set_label(f"Expected p-value ({labels[ipanel]})")
+            cbar.set_label(f"Expected p-value ({labels[i]})")
             ax.contour(
                 xcenters,
                 ycenters,
-                p_values[ipanel].reshape((grid_resolutions[0], grid_resolutions[1])).T,
+                panel.reshape((grid_resolutions[0], grid_resolutions[1])).T,
                 levels=levels,
-                colors=f"C{ipanel}",
+                colors=f"C{i}",
             )
             ax.scatter(
-                theta_grid[best_fits[ipanel]][0],
-                theta_grid[best_fits[ipanel]][1],
+                theta_grid[best_fits[i]][0],
+                theta_grid[best_fits[i]][1],
                 s=80.0,
-                color=f"C{ipanel}",
+                color=f"C{i}",
                 marker="*",
-                label=labels[ipanel],
+                label=labels[i],
             )
             ax.set_xlabel(xlabel)
             ax.set_ylabel(ylabel)

--- a/madminer/sampling/sampleaugmenter.py
+++ b/madminer/sampling/sampleaugmenter.py
@@ -68,7 +68,7 @@ class SampleAugmenter(DataAnalyzer):
     """
 
     def __init__(self, filename, disable_morphing=False, include_nuisance_parameters=True):
-        super(SampleAugmenter, self).__init__(filename, disable_morphing, include_nuisance_parameters)
+        super().__init__(filename, disable_morphing, include_nuisance_parameters)
 
     def sample_train_plain(
         self,

--- a/madminer/utils/interfaces/delphes_root.py
+++ b/madminer/utils/interfaces/delphes_root.py
@@ -439,12 +439,12 @@ def _get_particles_jets(tree, pt_min, eta_max):
         tau_tags = tree.array("Jet.TauTag")
     except:
         logger.warning("Did not find tau-tag information in Delphes ROOT file.")
-        tau_tags = [0 for _ in range(len(pts))]
+        tau_tags = [0] * len(pts)
     try:
         b_tags = tree.array("Jet.BTag")
     except:
         logger.warning("Did not find b-tag information in Delphes ROOT file.")
-        b_tags = [0 for _ in range(len(pts))]
+        b_tags = [0] * len(pts)
 
     all_particles = []
 
@@ -479,12 +479,12 @@ def _get_particles_truth_jets(tree, pt_min, eta_max):
         tau_tags = tree.array("GenJet.TauTag")
     except:
         logger.warning("Did not find tau-tag information for GenJets in Delphes ROOT file.")
-        tau_tags = [0 for _ in range(len(pts))]
+        tau_tags = [0] * len(pts)
     try:
         b_tags = tree.array("GenJet.BTag")
     except:
         logger.warning("Did not find b-tag information for GenJets in Delphes ROOT file.")
-        b_tags = [0 for _ in range(len(pts))]
+        b_tags = [0] * len(pts)
 
     all_particles = []
 

--- a/madminer/utils/ml/models/base.py
+++ b/madminer/utils/ml/models/base.py
@@ -9,7 +9,7 @@ class BaseFlow(nn.Module):
     """ """
 
     def __init__(self, n_inputs, **kwargs):
-        super(BaseFlow, self).__init__()
+        super().__init__()
         self.n_inputs = n_inputs
 
     def forward(self, x, **kwargs):
@@ -39,7 +39,7 @@ class BaseFlow(nn.Module):
 class BaseConditionalFlow(nn.Module):
 
     def __init__(self, n_conditionals, n_inputs, **kwargs):
-        super(BaseConditionalFlow, self).__init__()
+        super().__init__()
         self.n_conditionals = n_conditionals
         self.n_inputs = n_inputs
 

--- a/madminer/utils/ml/models/batch_norm.py
+++ b/madminer/utils/ml/models/batch_norm.py
@@ -12,8 +12,7 @@ class BatchNorm(BaseFlow):
     """BatchNorm implementation"""
 
     def __init__(self, n_inputs, alpha=0.1, eps=1.0e-5):
-
-        super(BatchNorm, self).__init__(n_inputs)
+        super().__init__(n_inputs)
 
         self.n_inputs = n_inputs
         self.alpha = alpha
@@ -25,7 +24,6 @@ class BatchNorm(BaseFlow):
         self.running_var = torch.zeros(self.n_inputs)
 
     def forward(self, x, fixed_params=False):
-
         """Calculates x -> u(x) (batch norming)"""
 
         # batch statistics
@@ -67,7 +65,7 @@ class BatchNorm(BaseFlow):
     def to(self, *args, **kwargs):
         logger.debug("Transforming BatchNorm to %s", args)
 
-        self = super(BatchNorm, self).to(*args, **kwargs)
+        self = super().to(*args, **kwargs)
 
         self.running_mean = self.running_mean.to(*args, **kwargs)
         self.running_var = self.running_var.to(*args, **kwargs)

--- a/madminer/utils/ml/models/made.py
+++ b/madminer/utils/ml/models/made.py
@@ -199,10 +199,6 @@ class ConditionalGaussianMADE(BaseConditionalFlow):
         x :
 
         **kwargs :
-<<<<<<< HEAD
-
-=======
->>>>>>> src: utils/ml/models module improve fmt
 
         Returns
         -------

--- a/madminer/utils/ml/models/made.py
+++ b/madminer/utils/ml/models/made.py
@@ -17,7 +17,7 @@ class GaussianMADE(BaseFlow):
     """ """
 
     def __init__(self, n_inputs, n_hiddens, activation="relu", input_order="sequential", mode="sequential"):
-        super(GaussianMADE, self).__init__(n_inputs)
+        super().__init__(n_inputs)
 
         # save input arguments
         self.activation = activation
@@ -134,7 +134,7 @@ class GaussianMADE(BaseFlow):
         self.to_args = args
         self.to_kwargs = kwargs
 
-        self = super(GaussianMADE, self).to(*args, **kwargs)
+        self = super().to(*args, **kwargs)
 
         for i, (M, W, b) in enumerate(zip(self.Ms, self.Ws, self.bs)):
             self.Ms[i] = M.to(*args, **kwargs)
@@ -162,7 +162,7 @@ class ConditionalGaussianMADE(BaseConditionalFlow):
         input_order="sequential",
         mode="sequential",
     ):
-        super(ConditionalGaussianMADE, self).__init__(n_conditionals, n_inputs)
+        super().__init__(n_conditionals, n_inputs)
 
         # save input arguments
         self.activation = activation
@@ -316,7 +316,7 @@ class ConditionalGaussianMADE(BaseConditionalFlow):
         self.to_args = args
         self.to_kwargs = kwargs
 
-        self = super(ConditionalGaussianMADE, self).to(*args, **kwargs)
+        self = super().to(*args, **kwargs)
 
         for i, (M, W, b) in enumerate(zip(self.Ms, self.Ws, self.bs)):
             self.Ms[i] = M.to(*args, **kwargs)

--- a/madminer/utils/ml/models/made_mog.py
+++ b/madminer/utils/ml/models/made_mog.py
@@ -25,7 +25,7 @@ class ConditionalMixtureMADE(BaseConditionalFlow):
         input_order="sequential",
         mode="sequential",
     ):
-        super(ConditionalMixtureMADE, self).__init__(n_conditionals, n_inputs)
+        super().__init__(n_conditionals, n_inputs)
 
         # save input arguments
         self.activation = activation
@@ -200,7 +200,7 @@ class ConditionalMixtureMADE(BaseConditionalFlow):
         self.to_args = args
         self.to_kwargs = kwargs
 
-        self = super(ConditionalMixtureMADE, self).to(*args, **kwargs)
+        self = super().to(*args, **kwargs)
 
         for i, M in enumerate(self.Ms):
             self.Ms[i] = M.to(*args, **kwargs)

--- a/madminer/utils/ml/models/maf.py
+++ b/madminer/utils/ml/models/maf.py
@@ -25,7 +25,7 @@ class MaskedAutoregressiveFlow(BaseFlow):
         alpha=0.1,
     ):
 
-        super(MaskedAutoregressiveFlow, self).__init__(n_inputs)
+        super().__init__(n_inputs)
 
         # save input arguments
         self.n_inputs = n_inputs
@@ -102,7 +102,7 @@ class MaskedAutoregressiveFlow(BaseFlow):
         self.to_args = args
         self.to_kwargs = kwargs
 
-        self = super(MaskedAutoregressiveFlow, self).to(*args, **kwargs)
+        self = super().to(*args, **kwargs)
 
         for i, (made) in enumerate(self.mades):
             self.mades[i] = made.to(*args, **kwargs)
@@ -130,7 +130,7 @@ class ConditionalMaskedAutoregressiveFlow(BaseConditionalFlow):
         alpha=0.1,
     ):
 
-        super(ConditionalMaskedAutoregressiveFlow, self).__init__(n_conditionals, n_inputs)
+        super().__init__(n_conditionals, n_inputs)
 
         # save input arguments
         self.n_conditionals = n_conditionals
@@ -257,7 +257,7 @@ class ConditionalMaskedAutoregressiveFlow(BaseConditionalFlow):
         self.to_args = args
         self.to_kwargs = kwargs
 
-        self = super(ConditionalMaskedAutoregressiveFlow, self).to(*args, **kwargs)
+        self = super().to(*args, **kwargs)
 
         for i, (made) in enumerate(self.mades):
             self.mades[i] = made.to(*args, **kwargs)

--- a/madminer/utils/ml/models/maf_mog.py
+++ b/madminer/utils/ml/models/maf_mog.py
@@ -26,7 +26,7 @@ class ConditionalMixtureMaskedAutoregressiveFlow(BaseConditionalFlow):
         alpha=0.1,
     ):
 
-        super(ConditionalMixtureMaskedAutoregressiveFlow, self).__init__(n_conditionals, n_inputs)
+        super().__init__(n_conditionals, n_inputs)
 
         # save input arguments
         self.n_conditionals = n_conditionals
@@ -136,7 +136,7 @@ class ConditionalMixtureMaskedAutoregressiveFlow(BaseConditionalFlow):
         self.to_args = args
         self.to_kwargs = kwargs
 
-        self = super(ConditionalMixtureMaskedAutoregressiveFlow, self).to(*args, **kwargs)
+        self = super().to(*args, **kwargs)
 
         for i, (made) in enumerate(self.mades):
             self.mades[i] = made.to(*args, **kwargs)

--- a/madminer/utils/ml/models/ratio.py
+++ b/madminer/utils/ml/models/ratio.py
@@ -14,8 +14,7 @@ class DenseSingleParameterizedRatioModel(nn.Module):
     numerator of the ratio is parameterized."""
 
     def __init__(self, n_observables, n_parameters, n_hidden, activation="tanh", dropout_prob=0.0):
-
-        super(DenseSingleParameterizedRatioModel, self).__init__()
+        super().__init__()
 
         # Save input
         self.n_hidden = n_hidden
@@ -39,7 +38,6 @@ class DenseSingleParameterizedRatioModel(nn.Module):
         self.append = self.layers.append(nn.Linear(n_last, 1))
 
     def forward(self, theta, x, track_score=True, return_grad_x=False, create_gradient_graph=True):
-
         """ Calculates estimated log likelihood ratio and the derived score. """
 
         # Track gradient wrt theta
@@ -89,7 +87,7 @@ class DenseSingleParameterizedRatioModel(nn.Module):
         return s_hat, log_r_hat, t_hat
 
     def to(self, *args, **kwargs):
-        self = super(DenseSingleParameterizedRatioModel, self).to(*args, **kwargs)
+        self = super().to(*args, **kwargs)
 
         for i, layer in enumerate(self.layers):
             self.layers[i] = layer.to(*args, **kwargs)
@@ -102,8 +100,7 @@ class DenseDoublyParameterizedRatioModel(nn.Module):
     numerator and denominator of the ratio are parameterized."""
 
     def __init__(self, n_observables, n_parameters, n_hidden, activation="tanh", dropout_prob=0.0):
-
-        super(DenseDoublyParameterizedRatioModel, self).__init__()
+        super().__init__()
 
         # Save input
         self.n_hidden = n_hidden
@@ -127,7 +124,6 @@ class DenseDoublyParameterizedRatioModel(nn.Module):
         self.layers.append(nn.Linear(n_last, 1))
 
     def forward(self, theta0, theta1, x, track_score=True, return_grad_x=False, create_gradient_graph=True):
-
         """ Calculates estimated log likelihood ratio and the derived score. """
 
         # Track gradient wrt thetas
@@ -199,7 +195,7 @@ class DenseDoublyParameterizedRatioModel(nn.Module):
         return s_hat, log_r_hat, t_hat0, t_hat1
 
     def to(self, *args, **kwargs):
-        self = super(DenseDoublyParameterizedRatioModel, self).to(*args, **kwargs)
+        self = super().to(*args, **kwargs)
 
         for i, layer in enumerate(self.layers):
             self.layers[i] = layer.to(*args, **kwargs)
@@ -212,8 +208,7 @@ class DenseComponentRatioModel(nn.Module):
     numerator of the ratio is parameterized."""
 
     def __init__(self, n_observables, n_hidden, activation="tanh", dropout_prob=0.0):
-
-        super(DenseComponentRatioModel, self).__init__()
+        super().__init__()
 
         # Save input
         self.n_hidden = n_hidden
@@ -249,7 +244,7 @@ class DenseComponentRatioModel(nn.Module):
         return log_r_hat
 
     def to(self, *args, **kwargs):
-        self = super(DenseComponentRatioModel, self).to(*args, **kwargs)
+        self = super().to(*args, **kwargs)
 
         for i, layer in enumerate(self.layers):
             self.layers[i] = layer.to(*args, **kwargs)
@@ -258,6 +253,7 @@ class DenseComponentRatioModel(nn.Module):
 
 
 class DenseMorphingAwareRatioModel(nn.Module):
+
     def __init__(
         self,
         components,
@@ -270,7 +266,7 @@ class DenseMorphingAwareRatioModel(nn.Module):
         clamp_component_ratios=5.0,
     ):
 
-        super(DenseMorphingAwareRatioModel, self).__init__()
+        super().__init__()
 
         # Save input
         self.n_hidden = n_hidden
@@ -295,7 +291,6 @@ class DenseMorphingAwareRatioModel(nn.Module):
         self.log_sigma_ratio_components = torch.nn.Parameter(torch.zeros((self.n_components, 1)))  # (n_components, 1)
 
     def forward(self, theta, x, track_score=True, return_grad_x=False, create_gradient_graph=True):
-
         """ Calculates estimated log likelihood ratio and the derived score. """
 
         # Track gradient wrt theta
@@ -403,9 +398,11 @@ class DenseMorphingAwareRatioModel(nn.Module):
 
 
 class DenseQuadraticMorphingAwareRatioModel(nn.Module):
+
     def __init__(self, n_observables, n_parameters, n_hidden, activation="tanh", dropout_prob=0.0):
+        super().__init__()
+
         assert n_parameters == 1
-        super(DenseQuadraticMorphingAwareRatioModel, self).__init__()
 
         # Save input
         self.n_hidden = n_hidden
@@ -419,7 +416,6 @@ class DenseQuadraticMorphingAwareRatioModel(nn.Module):
         self.sigma_b = torch.nn.Parameter(torch.ones((1,)))
 
     def forward(self, theta, x, track_score=True, return_grad_x=False, create_gradient_graph=True):
-
         """ Calculates estimated log likelihood ratio and the derived score. """
 
         assert theta.size()[1] == 1

--- a/madminer/utils/ml/models/score.py
+++ b/madminer/utils/ml/models/score.py
@@ -13,8 +13,7 @@ class DenseLocalScoreModel(nn.Module):
     of Fisher information matrices."""
 
     def __init__(self, n_observables, n_parameters, n_hidden, activation="tanh", dropout_prob=0.0):
-
-        super(DenseLocalScoreModel, self).__init__()
+        super().__init__()
 
         # Save input
         self.n_hidden = n_hidden
@@ -65,7 +64,7 @@ class DenseLocalScoreModel(nn.Module):
         return t_hat
 
     def to(self, *args, **kwargs):
-        self = super(DenseLocalScoreModel, self).to(*args, **kwargs)
+        self = super().to(*args, **kwargs)
 
         for i, layer in enumerate(self.layers):
             self.layers[i] = layer.to(*args, **kwargs)

--- a/madminer/utils/ml/trainer.py
+++ b/madminer/utils/ml/trainer.py
@@ -511,8 +511,9 @@ class Trainer:
 
 
 class SingleParameterizedRatioTrainer(Trainer):
+
     def __init__(self, model, run_on_gpu=True, double_precision=False, n_workers=8):
-        super(SingleParameterizedRatioTrainer, self).__init__(model, run_on_gpu, double_precision, n_workers)
+        super().__init__(model, run_on_gpu, double_precision, n_workers)
         self.calculate_model_score = True
 
     def check_data(self, data):
@@ -568,8 +569,9 @@ class SingleParameterizedRatioTrainer(Trainer):
 
 
 class DoubleParameterizedRatioTrainer(Trainer):
+
     def __init__(self, model, run_on_gpu=True, double_precision=False, n_workers=8):
-        super(DoubleParameterizedRatioTrainer, self).__init__(model, run_on_gpu, double_precision, n_workers)
+        super().__init__(model, run_on_gpu, double_precision, n_workers)
         self.calculate_model_score = True
 
     def check_data(self, data):
@@ -634,6 +636,7 @@ class DoubleParameterizedRatioTrainer(Trainer):
 
 
 class LocalScoreTrainer(Trainer):
+
     def check_data(self, data):
         data_keys = list(data.keys())
         if "x" not in data_keys or "t_xz" not in data_keys:
@@ -666,8 +669,9 @@ class LocalScoreTrainer(Trainer):
 
 
 class FlowTrainer(Trainer):
+
     def __init__(self, model, run_on_gpu=True, double_precision=False, n_workers=8):
-        super(FlowTrainer, self).__init__(model, run_on_gpu, double_precision, n_workers)
+        super().__init__(model, run_on_gpu, double_precision, n_workers)
         self.calculate_model_score = True
 
     def check_data(self, data):

--- a/madminer/utils/particle.py
+++ b/madminer/utils/particle.py
@@ -8,7 +8,7 @@ class MadMinerParticle(vector.MomentumObject4D):
     """ """
 
     def __init__(self, *args, **kwargs):
-        super(MadMinerParticle, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.charge = None
         self.pdgid = None
@@ -51,7 +51,7 @@ class MadMinerParticle(vector.MomentumObject4D):
 
     def __iadd__(self, other):
         assert isinstance(other, self.__class__)
-        super(MadMinerParticle, self).__iadd__(other)
+        super().__iadd__(other)
         self.charge = None if self.charge is None or other.charge is None else self.charge + other.charge
         self.pdgid = None
         self.spin = None
@@ -62,7 +62,7 @@ class MadMinerParticle(vector.MomentumObject4D):
 
     def __isub__(self, other):
         assert isinstance(other, self.__class__)
-        super(MadMinerParticle, self).__isub__(other)
+        super().__isub__(other)
         self.charge = None if self.charge is None or other.charge is None else self.charge - other.charge
         self.pdgid = None
         self.spin = None
@@ -76,7 +76,7 @@ class MadMinerParticle(vector.MomentumObject4D):
 
     def __add__(self, other):
         assert isinstance(other, self.__class__)
-        vec = super(MadMinerParticle, self).__add__(other)
+        vec = super().__add__(other)
         vec.charge = None if self.charge is None or other.charge is None else self.charge + other.charge
         vec.pdgid = None
         vec.spin = None
@@ -87,7 +87,7 @@ class MadMinerParticle(vector.MomentumObject4D):
 
     def __sub__(self, other):
         assert isinstance(other, self.__class__)
-        vec = super(MadMinerParticle, self).__sub__(other)
+        vec = super().__sub__(other)
         vec.charge = None if self.charge is None or other.charge is None else self.charge - other.charge
         vec.pdgid = None
         vec.spin = None
@@ -97,7 +97,7 @@ class MadMinerParticle(vector.MomentumObject4D):
         return vec
 
     def boost(self, *args):
-        vec = super(MadMinerParticle, self).boost(*args)
+        vec = super().boost(*args)
 
         particle = MadMinerParticle.from_xyzt(vec.x, vec.y, vec.z, vec.t)
         particle.charge = self.charge

--- a/madminer/utils/various.py
+++ b/madminer/utils/various.py
@@ -100,9 +100,8 @@ def shuffle(*arrays):
 
         if a.shape[0] != n_samples:
             raise RuntimeError(
-                "Mismatching shapes when trying to simultaneously shuffle: {}".format(
-                    [None if val is None else val.shape for val in arrays]
-                )
+                f"Mismatching shapes when trying to simultaneously shuffle: "
+                f"{[None if val is None else val.shape for val in arrays]}"
             )
 
         shuffled_a = a[permutation]


### PR DESCRIPTION
This PR continues to migrate Python2 compatible syntax to Python3. The main goal of the PR is to simplify the calls to the _superclass_ of all the defined classes from:

```python3
super(MyClassName, self)
```

to:
```python3
super()
```

This simplification revealed a couple of duplications and typos that required additional consideration:
- The [MorphingAwareRatioEstimator](https://github.com/diana-hep/madminer/blob/v0.8.1/madminer/ml/morphing_aware.py#L13) `super()` call specified the wrong type to infer the superclass from. Check https://github.com/diana-hep/madminer/commit/f1487d6d6cde29f84c7f3ef5cc89723777d8eff2.
- The [QuadraticMorphingAwareRatioEstimator](https://github.com/diana-hep/madminer/blob/v0.8.1/madminer/ml/morphing_aware.py#L96) `super().train` method could fail in its arg. overriding. Check https://github.com/diana-hep/madminer/commit/856bd48c526e2ac4429b2b076d83023ee4749c6e.
- The classes [ParametrizedRatioEstimator](https://github.com/diana-hep/madminer/blob/v0.8.1/madminer/ml/parameterized_ratio.py#L17) and [ScoreEstimator](https://github.com/diana-hep/madminer/blob/v0.8.1/madminer/ml/score.py#L16) had `calculate_fisher_information` methods that are pure duplications of their parent class one. Check https://github.com/diana-hep/madminer/commit/a59f297fba4f34b6680c00930ff0f626279d442d.

### Additional changes
- Additional error messages have been migrated to Python3 [f-strings](https://www.python.org/dev/peps/pep-0498/).
- An old GIT merge comment have been removed 🤦🏻‍♂️ .
- The initialization of _zero filled_ arrays have been simplified.
- The iteration over enumerations of elements have been simplified.