### PR TITLE
Fix vector classes inheritance

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,4 +14,4 @@ dependencies:
 - pip
 - pip:
   - uproot3>=3.14.1
-  - vector>=0.8.0
+  - vector>=0.8.4

--- a/madminer/utils/interfaces/lhe.py
+++ b/madminer/utils/interfaces/lhe.py
@@ -1049,7 +1049,7 @@ def _smear_particles(particles, energy_resolutions, pt_resolutions, eta_resoluti
             while pt <= min_pt:
                 pt = _smear_variable(particle.pt, pt_resolutions, pdgid)
         eta = _smear_variable(particle.eta, eta_resolutions, pdgid)
-        phi = _smear_variable(particle.phi(), phi_resolutions, pdgid)
+        phi = _smear_variable(particle.phi, phi_resolutions, pdgid)
         while phi > 2.0 * np.pi:
             phi -= 2.0 * np.pi
         while phi < 0.0:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ REQUIRED = [
     "scipy>=1.0.0",
     "torch>=1.0.0",
     "uproot3>=3.14.1",
-    "vector>=0.8.0",
+    "vector>=0.8.4",
 ]
 
 EXTRAS_DOCS = [


### PR DESCRIPTION
This PR bumps the [vector](https://github.com/scikit-hep/vector) package dependency to version `0.8.4`, addressing issue https://github.com/diana-hep/madminer/issues/470.

Version `0.8.4` allow the proper subclassing of `Vector` derived classes, as it does not require that children classes belong to its own package. Check [this PR](https://github.com/scikit-hep/vector/pull/128) for details.

In addition, it removes a legacy parenthesis around `particle.phi()`.