### PR TITLE
Use particle package as PDG ID utility

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,5 +13,6 @@ dependencies:
 - pytest
 - pip
 - pip:
+  - particle>=0.15.1
   - uproot3>=3.14.1
   - vector>=0.8.4

--- a/madminer/delphes/delphes_reader.py
+++ b/madminer/delphes/delphes_reader.py
@@ -363,7 +363,7 @@ class DelphesReader:
             object. `visible` and `all` provide access to the sum of all visible particles and the sum of all visible
             particles plus MET, respectively. In addition, `MadMinerParticle` have  properties `charge` and `pdg_id`,
             which return the charge in units of elementary charges (i.e. an electron has `e[0].charge = -1.`), and the
-            PDG particle ID. For instance, `"abs(j[0].phi() - j[1].phi())"` defines the azimuthal angle between the two
+            PDG particle ID. For instance, `"abs(j[0].phi - j[1].phi)"` defines the azimuthal angle between the two
             hardest jets.
 
         required : bool, optional
@@ -480,7 +480,7 @@ class DelphesReader:
         # ETMiss
         if include_met:
             self.add_observable("et_miss", "met.pt", required=True)
-            self.add_observable("phi_miss", "met.phi()", required=True)
+            self.add_observable("phi_miss", "met.phi", required=True)
 
         # Sum of visible particles
         if include_visible_sum:
@@ -505,7 +505,7 @@ class DelphesReader:
                     f"eta_{symbol}{i+1}", f"{symbol}[{i}].eta", required=False, default=0.0
                 )
                 self.add_observable(
-                    f"phi_{symbol}{i+1}", f"{symbol}[{i}].phi()", required=False, default=0.0
+                    f"phi_{symbol}{i+1}", f"{symbol}[{i}].phi", required=False, default=0.0
                 )
                 if include_this_charge and symbol == "l":
                     self.add_observable(

--- a/madminer/lhe/lhe_reader.py
+++ b/madminer/lhe/lhe_reader.py
@@ -78,9 +78,7 @@ class LHEReader:
         self.eta_resolution = {}
         self.phi_resolution = {}
 
-        pdgids = [1, -1, 2, -2, 3, -3, 4, -4, 5, -5, 6, -6, 9]
-        pdgids += [11, -11, 12, -12, 13, -13, 14, -14, 15, -15, 16, -16, 21, 22, 23, 24, -24, 25]
-        for pdgid in pdgids:
+        for pdgid in get_elementary_pdg_ids():
             self.energy_resolution[pdgid] = (0.0, 0.0)
             self.pt_resolution[pdgid] = (0.0, 0.0)
             self.eta_resolution[pdgid] = (0.0, 0.0)

--- a/madminer/lhe/lhe_reader.py
+++ b/madminer/lhe/lhe_reader.py
@@ -302,7 +302,7 @@ class LHEReader:
             missing ET object. `p` gives all particles in the same order as in the LHE file (i.e. in the same order as
             defined in the MadGraph process card). In addition, `MadMinerParticle` have  properties `charge` and `pdg_id`,
             which return the charge in units of elementary charges (i.e. an electron has `e[0].charge = -1.`), and the
-            PDG particle ID. For instance, `"abs(j[0].phi() - j[1].phi())"` defines the azimuthal angle between the two
+            PDG particle ID. For instance, `"abs(j[0].phi - j[1].phi)"` defines the azimuthal angle between the two
             hardest jets.
 
         required : bool, optional
@@ -418,7 +418,7 @@ class LHEReader:
         # ETMiss
         if include_met:
             self.add_observable("et_miss", "met.pt", required=True)
-            self.add_observable("phi_miss", "met.phi()", required=True)
+            self.add_observable("phi_miss", "met.phi", required=True)
 
         # Sum of visible particles
         if include_visible_sum:
@@ -443,7 +443,7 @@ class LHEReader:
                     f"eta_{symbol}{i+1}", f"{symbol}[{i}].eta", required=False, default=0.0
                 )
                 self.add_observable(
-                    f"phi_{symbol}{i+1}", f"{symbol}[{i}].phi()", required=False, default=0.0
+                    f"phi_{symbol}{i+1}", f"{symbol}[{i}].phi", required=False, default=0.0
                 )
                 if include_this_charge and symbol == "l":
                     self.add_observable(

--- a/madminer/utils/interfaces/delphes_root.py
+++ b/madminer/utils/interfaces/delphes_root.py
@@ -265,7 +265,7 @@ def _get_particles_truth(tree, pt_min, eta_max, included_pdgids=None):
                 continue
             if eta_max is not None and abs(eta) > eta_max:
                 continue
-            if (included_pdgids is not None) and (not pdgid in included_pdgids):
+            if (included_pdgids is not None) and (pdgid not in included_pdgids):
                 continue
 
             particle = MadMinerParticle.from_rhophietat(pt, phi, eta, e)

--- a/madminer/utils/interfaces/delphes_root.py
+++ b/madminer/utils/interfaces/delphes_root.py
@@ -3,6 +3,7 @@ import numpy as np
 import os
 import uproot3
 from collections import OrderedDict
+from particle import Particle
 
 from madminer.utils.particle import MadMinerParticle
 from madminer.utils.various import math_commands
@@ -307,10 +308,13 @@ def _get_particles_charged(tree, name, mass, pdgid_positive_charge, pt_min, eta_
 
 
 def _get_particles_leptons(tree, pt_min_e, eta_max_e, pt_min_mu, eta_max_mu):
+    ids_mu = {int(p.pdgid) for p in Particle.findall(pdg_name="mu")}
     pt_mu = tree.array("Muon.PT")
     eta_mu = tree.array("Muon.Eta")
     phi_mu = tree.array("Muon.Phi")
     charge_mu = tree.array("Muon.Charge")
+
+    ids_e = {int(p.pdgid) for p in Particle.findall(pdg_name="e")}
     pt_e = tree.array("Electron.PT")
     eta_e = tree.array("Electron.Eta")
     phi_e = tree.array("Electron.Phi")
@@ -344,13 +348,13 @@ def _get_particles_leptons(tree, pt_min_e, eta_max_e, pt_min_mu, eta_max_mu):
 
             pdgid = pdgid_positive_charge if charge >= 0.0 else -pdgid_positive_charge
 
-            if abs(int(pdgid)) == 11:
+            if int(pdgid) in ids_e:
                 if pt_min_e is not None and pt < pt_min_e:
                     continue
                 if eta_max_e is not None and abs(eta) > eta_max_e:
                     continue
 
-            elif abs(int(pdgid)) == 13:
+            elif int(pdgid) in ids_mu:
                 if pt_min_mu is not None and pt < pt_min_mu:
                     continue
                 if eta_max_mu is not None and abs(eta) > eta_max_mu:
@@ -370,6 +374,8 @@ def _get_particles_leptons(tree, pt_min_e, eta_max_e, pt_min_mu, eta_max_mu):
 
 
 def _get_particles_truth_leptons(tree, pt_min_e, eta_max_e, pt_min_mu, eta_max_mu):
+    ids_e = {int(p.pdgid) for p in Particle.findall(pdg_name="e")}
+    ids_mu = {int(p.pdgid) for p in Particle.findall(pdg_name="mu")}
     es = tree.array("Particle.E")
     pts = tree.array("Particle.PT")
     etas = tree.array("Particle.Eta")
@@ -383,15 +389,15 @@ def _get_particles_truth_leptons(tree, pt_min_e, eta_max_e, pt_min_mu, eta_max_m
         event_particles = []
 
         for e, pt, eta, phi, pdgid in zip(es[ievent], pts[ievent], etas[ievent], phis[ievent], pdgids[ievent]):
-            if pdgid not in [11, 13, -11, -13]:
+            if pdgid not in {*ids_e, *ids_mu}:
                 continue
-            if pdgid in [11, -11] and (pt_min_e is not None and pt < pt_min_e):
+            if pdgid in ids_e and (pt_min_e is not None and pt < pt_min_e):
                 continue
-            if pdgid in [11, -11] and (eta_max_e is not None and abs(eta) > eta_max_e):
+            if pdgid in ids_e and (eta_max_e is not None and abs(eta) > eta_max_e):
                 continue
-            if pdgid in [13, -13] and (pt_min_mu is not None and pt < pt_min_mu):
+            if pdgid in ids_mu and (pt_min_mu is not None and pt < pt_min_mu):
                 continue
-            if pdgid in [13, -13] and (eta_max_mu is not None and abs(eta) > eta_max_mu):
+            if pdgid in ids_mu and (eta_max_mu is not None and abs(eta) > eta_max_mu):
                 continue
 
             particle = MadMinerParticle.from_rhophietat(pt, phi, eta, e)

--- a/madminer/utils/particle.py
+++ b/madminer/utils/particle.py
@@ -6,6 +6,11 @@ from particle import Particle
 logger = logging.getLogger(__name__)
 
 
+B_PDG_IDS = {int(p.pdgid) for p in Particle.findall(pdg_name="b")}
+T_PDG_IDS = {int(p.pdgid) for p in Particle.findall(pdg_name="t")}
+TAU_PDG_IDS = {int(p.pdgid) for p in Particle.findall(pdg_name="tau")}
+
+
 class MadMinerParticle(vector.MomentumObject4D):
     """ """
 
@@ -28,11 +33,11 @@ class MadMinerParticle(vector.MomentumObject4D):
         self.pdgid = int(pdgid)
         self.charge = Particle.from_pdgid(self.pdgid).charge
 
-        if self.pdgid in [5, -5]:
+        if self.pdgid in B_PDG_IDS:
             self.b_tag = True
-        elif self.pdgid in [6, -6]:
+        elif self.pdgid in T_PDG_IDS:
             self.t_tag = True
-        elif self.pdgid in [15, -15]:
+        elif self.pdgid in TAU_PDG_IDS:
             self.tau_tag = True
 
     def set_spin(self, spin):

--- a/madminer/utils/particle.py
+++ b/madminer/utils/particle.py
@@ -1,6 +1,8 @@
 import logging
 import vector
 
+from particle import Particle
+
 logger = logging.getLogger(__name__)
 
 
@@ -24,20 +26,7 @@ class MadMinerParticle(vector.MomentumObject4D):
 
     def set_pdgid(self, pdgid):
         self.pdgid = int(pdgid)
-        self.charge = 0.0
-
-        if self.pdgid in [11, 13, 15, -24]:
-            self.charge = -1.0
-        elif self.pdgid in [-11, -13, -15, 24]:
-            self.charge = 1.0
-        elif self.pdgid in [1, 3, 5]:
-            self.charge = 2.0 / 3.0
-        elif self.pdgid in [-1, -3, -5]:
-            self.charge = -2.0 / 3.0
-        elif self.pdgid in [2, 4, 6]:
-            self.charge = -1.0 / 3.0
-        elif self.pdgid in [-2, -4, -6]:
-            self.charge = 1.0 / 3.0
+        self.charge = Particle.from_pdgid(self.pdgid).charge
 
         if self.pdgid in [5, -5]:
             self.b_tag = True

--- a/madminer/utils/various.py
+++ b/madminer/utils/various.py
@@ -1,5 +1,6 @@
 import logging
 import gzip
+import math
 import numpy as np
 import os
 import shutil
@@ -190,34 +191,25 @@ def load_and_check(filename, warning_threshold=1.0e9, memmap_files_larger_than_g
 
 def math_commands():
     """Provides list with math commands - we need this when using eval"""
-
-    from math import acos, asin, atan, atan2, ceil, cos, cosh, exp, floor, log, pi, pow, sin, sinh, sqrt, tan, tanh
-
-    functions = [
-        "acos",
-        "asin",
-        "atan",
-        "atan2",
-        "ceil",
-        "cos",
-        "cosh",
-        "exp",
-        "floor",
-        "log",
-        "pi",
-        "pow",
-        "sin",
-        "sinh",
-        "sqrt",
-        "tan",
-        "tanh",
-    ]
-
-    mathdefinitions = {}
-    for f in functions:
-        mathdefinitions[f] = locals().get(f, None)
-
-    return mathdefinitions
+    return {
+        "acos": math.acos,
+        "asin": math.asin,
+        "atan": math.atan,
+        "atan2": math.atan2,
+        "ceil": math.ceil,
+        "cos": math.cos,
+        "cosh": math.cosh,
+        "exp": math.exp,
+        "floor": math.floor,
+        "log": math.log,
+        "pi": math.pi,
+        "pow": math.pow,
+        "sin": math.sin,
+        "sinh": math.sinh,
+        "sqrt": math.sqrt,
+        "tan": math.tan,
+        "tanh": math.tanh,
+    }
 
 
 def make_file_executable(filename):

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ REQUIRED = [
     "h5py",
     "matplotlib>=2.0.0",
     "numpy>=1.13.0",
+    "particle>=0.15.1",
     "scipy>=1.0.0",
     "torch>=1.0.0",
     "uproot3>=3.14.1",

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Based on https://github.com/kennethreitz/setup.py
-
-# Note: To use the 'upload' functionality of this file, you must:
-#   $ pip install twine
-
-import os
-import sys
 from pathlib import Path
-from shutil import rmtree
-
-from setuptools import find_packages, setup, Command
+from setuptools import find_packages, setup
 
 
 project_dir = Path(__file__).parent
@@ -62,43 +53,6 @@ EXTRAS_EXAMPLES = [
 ]
 
 
-class UploadCommand(Command):
-    """Support setup.py upload."""
-
-    description = 'Build and publish the package.'
-    user_options = []
-
-    @staticmethod
-    def status(s):
-        """Prints things in bold."""
-        print('\033[1m{0}\033[0m'.format(s))
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        try:
-            self.status('Removing previous builds…')
-            rmtree(os.path.join(project_dir, 'dist'))
-        except OSError:
-            pass
-
-        self.status('Building Source and Wheel (universal) distribution…')
-        os.system('{0} setup.py sdist bdist_wheel'.format(sys.executable))
-
-        self.status('Uploading the package to PyPI via Twine…')
-        os.system('twine upload dist/*')
-
-        self.status('Pushing git tags…')
-        os.system('git tag v{0}'.format(VERSION))
-        os.system('git push --tags')
-
-        sys.exit()
-
-
 setup(
     name=NAME,
     version=VERSION,
@@ -128,8 +82,4 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],
-    # $ setup.py publish support.
-    cmdclass={
-        'upload': UploadCommand,
-    },
 )


### PR DESCRIPTION
This PR covers the introduction of the [scikit-hep/particle](https://github.com/scikit-hep/particle) package into the codebase, to replace most of the hardcoded PDG IDs throughout the codebase.

The particle package allows for the _meaningful_ search of particles by specifying their name, or any other arbitrary filter function thanks to the [Particle.findall(...)](https://github.com/scikit-hep/particle/blob/3dad2d83684aba8e140417274775f1e1621cb3d2/src/particle/particle/particle.py#L1035-L1041) function. In addition, [Particle.from_pdgid(...)](https://github.com/scikit-hep/particle/blob/3dad2d83684aba8e140417274775f1e1621cb3d2/src/particle/particle/particle.py#L1012-L1013) has been used within the MadminerParticle class to obtain the charge of specific particles given their PDG ID (some of them were wrongly defined).


### Additional changes
- Simplified utils/various.py `math_commands` utility function. https://github.com/diana-hep/madminer/commit/eb94d8756d547f08e9071794266e580a842d3e5d
- Removed legacy setup.py `UploadCommand` utility (currently using a [GHA workflows](https://github.com/diana-hep/madminer/blob/7be2352efa7174c42629ab299159115671f1ce49/.github/workflows/publish.yml#L40-L68) upon _published_  events). https://github.com/diana-hep/madminer/commit/ad27cabaa1f3b65e93fd6abadb3af0a4cbd666d5
- Fix deprecated `particle.phi()` occurrences (since the [scikit-hep/vector](https://github.com/scikit-hep/vector) migration, `phi` is not callable). https://github.com/diana-hep/madminer/commit/1ad9e69cb20631d50f35c66b516ddf95d5c41a37


---

Guidance on these substitutions was provided by @eduardo-rodrigues 