### PR TITLE
Modernize syntax to particle v0.16.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,6 @@ dependencies:
 - pytest
 - pip
 - pip:
-  - particle>=0.15.1
+  - particle>=0.16.0
   - uproot3>=3.14.1
   - vector>=0.8.4

--- a/madminer/utils/interfaces/lhe.py
+++ b/madminer/utils/interfaces/lhe.py
@@ -1086,15 +1086,13 @@ def _smear_particles(particles, energy_resolutions, pt_resolutions, eta_resoluti
 
 
 def get_elementary_pdg_ids():
-    """Get Standard Model elementary particle IDs, leaving out 4th generation leptons"""
+    """Get Standard Model elementary particle IDs"""
     pdg_ids = Particle.findall(
         lambda p: (
-            p.pdgid.is_quark
-            or p.pdgid.is_lepton
+            p.pdgid.is_sm_quark
+            or p.pdgid.is_sm_lepton
             or p.pdgid.is_sm_gauge_boson_or_higgs
         )
     )
 
-    pdg_ids = [int(p.pdgid) for p in pdg_ids]
-    pdg_ids = [pdg_id for pdg_id in pdg_ids if pdg_id not in {17, -17, 18, -18}]
-    return pdg_ids
+    return [int(p.pdgid) for p in pdg_ids]

--- a/madminer/utils/interfaces/lhe.py
+++ b/madminer/utils/interfaces/lhe.py
@@ -946,11 +946,10 @@ def _get_objects(particles, particles_truth, met_resolution=None, global_event_d
     visible_sum = MadMinerParticle.from_xyzt(0.0, 0.0, 0.0, 0.0)
 
     standard_ids = set(get_elementary_pdg_ids())
-    neutrino_ids = {int(p.pdgid) for p in [
-        *Particle.findall(pdg_name="nu(e)"),
-        *Particle.findall(pdg_name="nu(mu)"),
-        *Particle.findall(pdg_name="nu(tau)"),
-    ]}
+    neutrino_ids = set(
+        int(p.pdgid)
+        for p in Particle.findall(lambda p: p.pdgid.is_sm_lepton and p.charge == 0)
+    )
 
     for particle in particles:
         if particle.pdgid in standard_ids and particle.pdgid not in neutrino_ids:

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ REQUIRED = [
     "h5py",
     "matplotlib>=2.0.0",
     "numpy>=1.13.0",
-    "particle>=0.15.1",
+    "particle>=0.16.0",
     "scipy>=1.0.0",
     "torch>=1.0.0",
     "uproot3>=3.14.1",


### PR DESCRIPTION
This PR modernizes syntax around the [scikit-hep/particle](https://github.com/scikit-hep/particle) package upon version `0.16.0` release.

The changes were already hinted by Eduardo Rodriguez on [this PR](https://github.com/diana-hep/madminer/pull/476).
- [Comment](https://github.com/diana-hep/madminer/pull/476#discussion_r696173709) about the neutrino IDs snippet.
- [Comment](https://github.com/diana-hep/madminer/pull/476#discussion_r696177288) about the Standard Model particles.