### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - name: "Set up GitHub Actions"
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
     steps:
     - name: "Set up GitHub Actions"
       uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
     - name: "Set up Python 3.6"
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: "Install Python dependencies"
       run: |
         pip install --no-cache-dir --upgrade pip setuptools wheel

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,10 +11,9 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
 
-# Equivalent to:
-# $ python -m pip install .[docs]
+# Equivalent to: pip install .[docs]
 python:
-  version: 3.7
+  version: "3.7"
   install:
     - method: pip
       path: .

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@
 
 Make sure the following tools are installed and running:
 - MadGraph (we have tested our setup with version 2.8.0+). See [MadGraph's website][web-madgraph-main-page]
-  for installation instructions. Note that MadGraph requires a Fortran compiler as well as Python 3.6+.
+  for installation instructions. Note that MadGraph requires a Fortran compiler as well as Python 3.7+.
 - For the analysis of systematic uncertainties, LHAPDF6 has to be installed with Python support
   (see also [the documentation of MadGraph's systematics tool][web-madgraph-systematics]).
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 - anaconda
 - defaults
 dependencies:
-- python=3.6.*
+- python=3.7.*
 - h5py
 - matplotlib>=2.0.0
 - numpy>=1.13.0

--- a/setup.py
+++ b/setup.py
@@ -80,5 +80,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ NAME = 'madminer'
 DESCRIPTION = 'Mining gold from MadGraph to improve limit setting in particle physics.'
 URL = 'https://github.com/diana-hep/madminer'
 EMAIL = 'johann.brehmer@nyu.edu'
-REQUIRES_PYTHON = '>=3.6, <4'
+REQUIRES_PYTHON = '>=3.7, <4'
 AUTHORS = info['__authors__']
 VERSION = info['__version__']
 REQUIRED = [
@@ -78,7 +78,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],


### PR DESCRIPTION
This PR continues the work towards completing issue https://github.com/diana-hep/madminer/issues/482, by dropping support for Python 3.6.

The reason for dropping support, is the lack of [Python Data-classes](https://docs.python.org/3.7/library/dataclasses.html) (introduced in Python 3.7), in addition to the upcoming release of Python 3.10 (there would be too many versions being supported otherwise: 3.6, 3.7, 3.8, 3.9 and 3.10).

Finally, Python 3.9 has been added to [the CI workflow matrix](https://github.com/Sinclert/madminer/blob/102936951c0d78c42ac710f7929c681032010564/.github/workflows/ci.yml#L29).

