### PR TITLE
Bump Numpy version to 1.20.0+

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - python=3.7.*
 - h5py
 - matplotlib>=2.0.0
-- numpy>=1.13.0
+- numpy>=1.20.0
 - scipy>=1.0.0
 - pytorch>=1.0.0
 - pytest

--- a/madminer/analysis/dataanalyzer.py
+++ b/madminer/analysis/dataanalyzer.py
@@ -938,7 +938,7 @@ class DataAnalyzer:
         return dtheta_matrix
 
     def _calculate_sampling_factors(self):
-        events = np.asarray(self.n_events_generated_per_benchmark, dtype=np.float)
+        events = np.asarray(self.n_events_generated_per_benchmark, dtype=np.float64)
         logger.debug(f"Events per benchmark: {events}")
         factors = events / np.sum(events)
         factors = np.hstack((factors, 1.0))  # background events

--- a/madminer/delphes/delphes_reader.py
+++ b/madminer/delphes/delphes_reader.py
@@ -657,7 +657,7 @@ class DelphesReader:
             else:
                 idx = self.benchmark_names_phys.index(sampling_benchmark)
                 self.signal_events_per_benchmark[idx] += this_n_events
-            this_events_sampling_benchmark_ids = np.array([idx] * this_n_events, dtype=np.int)
+            this_events_sampling_benchmark_ids = np.array([idx] * this_n_events, dtype=int)
 
             # First results
             if self.observations is None and self.weights is None:

--- a/madminer/lhe/lhe_reader.py
+++ b/madminer/lhe/lhe_reader.py
@@ -625,7 +625,7 @@ class LHEReader:
             else:
                 idx = self.benchmark_names_phys.index(sampling_benchmark)
                 self.signal_events_per_benchmark[idx] += this_n_events
-            this_events_sampling_benchmark_ids = np.array([idx] * this_n_events, dtype=np.int)
+            this_events_sampling_benchmark_ids = np.array([idx] * this_n_events, dtype=int)
 
             # First results
             if self.observations is None and self.weights is None:

--- a/madminer/plotting/distributions.py
+++ b/madminer/plotting/distributions.py
@@ -207,7 +207,7 @@ def plot_distributions(
     all_weights_benchmarks = all_weights_benchmarks[sane_event_filter]
     n_events_removed = n_events_before - all_weights_benchmarks.shape[0]
 
-    if int(np.sum(sane_event_filter, dtype=np.int)) < len(sane_event_filter):
+    if int(np.sum(sane_event_filter, dtype=int)) < len(sane_event_filter):
         logger.warning("Removed %s / %s events with negative weights", n_events_removed, n_events_before)
 
     for i, (x, weights) in enumerate(zip(indiv_x, indiv_weights_benchmarks)):

--- a/madminer/sampling/combine.py
+++ b/madminer/sampling/combine.py
@@ -23,7 +23,7 @@ def _calculate_n_events(sampling_ids, n_benchmarks):
     results = dict(zip(unique, counts))
 
     n_events_backgrounds = results.get(-1, 0)
-    n_events_signal_per_benchmark = np.array([results.get(i, 0) for i in range(n_benchmarks)], dtype=np.int)
+    n_events_signal_per_benchmark = np.array([results.get(i, 0) for i in range(n_benchmarks)], dtype=int)
     return n_events_signal_per_benchmark, n_events_backgrounds
 
 

--- a/madminer/sampling/sampleaugmenter.py
+++ b/madminer/sampling/sampleaugmenter.py
@@ -1560,7 +1560,7 @@ class SampleAugmenter(DataAnalyzer):
                 )
 
         # Prepare output
-        done = np.zeros(n_samples, dtype=np.bool)
+        done = np.zeros(n_samples, dtype=bool)
         x = np.zeros((n_samples, self.n_observables), dtype=dtype)
         augmented_data = []
         for definition in augmented_data_definitions:

--- a/madminer/utils/interfaces/delphes_root.py
+++ b/madminer/utils/interfaces/delphes_root.py
@@ -176,7 +176,7 @@ def parse_delphes_root_file(
             finally:
                 values_this_cut.append(value)
 
-        values_this_cut = np.array(values_this_cut, dtype=np.bool)
+        values_this_cut = np.array(values_this_cut, dtype=bool)
         cut_values.append(values_this_cut)
 
     # Check for existence of required observables

--- a/madminer/utils/interfaces/delphes_root.py
+++ b/madminer/utils/interfaces/delphes_root.py
@@ -334,7 +334,7 @@ def _get_particles_leptons(tree, pt_min_e, eta_max_e, pt_min_mu, eta_max_mu):
         event_masses = np.concatenate((0.105 * np.ones_like(pt_mu[ievent]), 0.000511 * np.ones_like(pt_e[ievent])))
         event_charges = np.concatenate((charge_mu[ievent], charge_e[ievent]))
         event_pdgid_positive_charges = np.concatenate(
-            (-13 * np.ones_like(pt_mu[ievent], dtype=np.int), -11 * np.ones_like(pt_e[ievent], dtype=np.int))
+            (-13 * np.ones_like(pt_mu[ievent], dtype=int), -11 * np.ones_like(pt_e[ievent], dtype=int))
         )
 
         # Sort by descending pT

--- a/madminer/utils/interfaces/delphes_root.py
+++ b/madminer/utils/interfaces/delphes_root.py
@@ -151,7 +151,7 @@ def parse_delphes_root_file(
             finally:
                 values_this_observable.append(value)
 
-        values_this_observable = np.array(values_this_observable, dtype=np.float)
+        values_this_observable = np.array(values_this_observable, dtype=np.float64)
         observable_values[name] = values_this_observable
 
         logger.debug("  First 10 values for observable %s:\n%s", name, values_this_observable[:10])

--- a/madminer/utils/interfaces/hdf5.py
+++ b/madminer/utils/interfaces/hdf5.py
@@ -320,7 +320,7 @@ def load_events(
         include_nuisance_params = True
 
     elif include_nuisance_params is False and benchmark_nuisance_flags is not None:
-        benchmark_filter = np.logical_not(np.array(benchmark_nuisance_flags, dtype=np.bool))
+        benchmark_filter = np.logical_not(np.array(benchmark_nuisance_flags, dtype=bool))
 
     (
         observations,

--- a/madminer/utils/interfaces/hdf5.py
+++ b/madminer/utils/interfaces/hdf5.py
@@ -705,7 +705,7 @@ def _load_morphing(file_name: str) -> Tuple[np.ndarray, np.ndarray]:
             logger.error("HDF5 file does not contain morphing information")
         else:
             morphing_components = np.asarray(morphing_components, dtype=int)
-            morphing_matrix = np.asarray(morphing_matrix, dtype=np.float)
+            morphing_matrix = np.asarray(morphing_matrix, dtype=np.float64)
 
     return morphing_components, morphing_matrix
 

--- a/madminer/utils/interfaces/hdf5.py
+++ b/madminer/utils/interfaces/hdf5.py
@@ -424,7 +424,7 @@ def save_events(
 
     sample_observations = np.array(observations).T
     sample_weights = np.array(sorted_weights).T
-    sampling_ids = np.array(sampling_benchmarks, dtype=np.int)
+    sampling_ids = np.array(sampling_benchmarks, dtype=int)
 
     _save_samples(file_name, file_override, sample_observations, sample_weights, sampling_ids)
     _save_samples_summary(file_name, file_override, num_signal_events, num_background_events)
@@ -704,7 +704,7 @@ def _load_morphing(file_name: str) -> Tuple[np.ndarray, np.ndarray]:
         except KeyError:
             logger.error("HDF5 file does not contain morphing information")
         else:
-            morphing_components = np.asarray(morphing_components, dtype=np.int)
+            morphing_components = np.asarray(morphing_components, dtype=int)
             morphing_matrix = np.asarray(morphing_matrix, dtype=np.float)
 
     return morphing_components, morphing_matrix

--- a/madminer/utils/morphing.py
+++ b/madminer/utils/morphing.py
@@ -77,7 +77,7 @@ class PhysicsMorpher:
             self.parameter_max_power = [param.max_power for param in parameters_from_madminer.values()]
             self.parameter_range = [param.val_range for param in parameters_from_madminer.values()]
 
-            self.parameter_max_power = np.array(self.parameter_max_power, dtype=np.int)
+            self.parameter_max_power = np.array(self.parameter_max_power, dtype=int)
             self.parameter_range = np.array(self.parameter_range)
 
         # Generic interface
@@ -138,7 +138,7 @@ class PhysicsMorpher:
         # Go through regions and finds components for each
         components = []
         for powers in itertools.product(*powers_each_component):
-            powers = np.array(powers, dtype=np.int)
+            powers = np.array(powers, dtype=int)
 
             if np.sum(powers) > max_overall_power:
                 continue
@@ -149,7 +149,7 @@ class PhysicsMorpher:
             else:
                 logger.debug("  Not adding component %s again", powers)
 
-        self.components = np.array(components, dtype=np.int)
+        self.components = np.array(components, dtype=int)
         self.n_components = len(self.components)
 
         return self.components

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ VERSION = info['__version__']
 REQUIRED = [
     "h5py",
     "matplotlib>=2.0.0",
-    "numpy>=1.13.0",
+    "numpy>=1.20.0",
     "particle>=0.16.0",
     "scipy>=1.0.0",
     "torch>=1.0.0",


### PR DESCRIPTION
This PR upgrades the minimum [numpy](https://github.com/numpy/numpy) requirements to version `1.20.0`. In addition, it substitute the [deprecated `dtypes`](https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated) by their closest equivalents:

- `np.int` -> `int`. Equivalent.
- `np.bool` -> `bool`. Equivalent.
- `np.float` -> `np.float64`. More precise.
